### PR TITLE
Add Docusaurus deployment workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,47 @@
+name: Deploy Docusaurus
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'wiki/**'
+      - '.github/workflows/deploy-docs.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: 'deploy-docs'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+          cache-dependency-path: wiki/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+        working-directory: wiki
+      - name: Build Docusaurus
+        run: npm run build
+        working-directory: wiki
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: wiki/build
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- build Docusaurus site from `wiki` on each main push
- upload the built site and deploy using GitHub Pages

## Testing
- `npm ci` in `wiki`
- `npm run build` *(fails: MDX compilation error)*

------
https://chatgpt.com/codex/tasks/task_e_6886054b672c8324a3473d4c165cfdc6