### PR TITLE
Fix gh-pages deployment permission

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,5 +1,13 @@
 name: Deploy Docusaurus
 
+# Explicitly grant the workflow permission to push changes using
+# the automatically provided `GITHUB_TOKEN`. Without this setting the
+# token only has read access which results in a 403 when the
+# `peaceiris/actions-gh-pages` action tries to push to the `gh-pages`
+# branch.
+permissions:
+  contents: write
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
## Summary
- enable workflow to push to gh-pages branch by granting contents write permission

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68866fa80f2083249b098871337254ad