### PR TITLE
Implement SteamEmitter player interaction

### DIFF
--- a/Assets/Scripts/Generators/LevelGenerator.cs
+++ b/Assets/Scripts/Generators/LevelGenerator.cs
@@ -240,6 +240,12 @@ public class LevelGenerator : MonoBehaviour
                 }
                 
                 OnLevelGenerationCompleted?.Invoke(activeProfile);
+
+                if (showGenerationDebug)
+                {
+                    int count = FindObjectsOfType<RollABall.VFX.SteamEmitterController>().Count(e => e.HasMovementInfluence);
+                    Debug.Log($"Steam emitters affecting player: {count}");
+                }
             }
             catch (System.Exception e)
             {
@@ -1137,18 +1143,22 @@ public class LevelGenerator : MonoBehaviour
                         // Apply steam settings if a compatible controller exists
                         if (activeProfile.SteamSettings != null)
                         {
-                            emitter.SendMessage("ApplyProfile", activeProfile.SteamSettings, SendMessageOptions.DontRequireReceiver);
-
-                            if (activeProfile.SteamSettings.SteamSounds != null && activeProfile.SteamSettings.SteamSounds.Length > 0)
+                            var controller = emitter.GetComponent<RollABall.VFX.SteamEmitterController>();
+                            if (controller)
                             {
-                                AudioClip steamClip = activeProfile.SteamSettings.SteamSounds[random.Next(activeProfile.SteamSettings.SteamSounds.Length)];
-                                emitter.SendMessage("SetSteamSound", steamClip, SendMessageOptions.DontRequireReceiver);
-                            }
+                                controller.Init(activeProfile.SteamSettings);
 
-                            if (activeProfile.SteamSettings.MechanicalSounds != null && activeProfile.SteamSettings.MechanicalSounds.Length > 0)
-                            {
-                                AudioClip mechClip = activeProfile.SteamSettings.MechanicalSounds[random.Next(activeProfile.SteamSettings.MechanicalSounds.Length)];
-                                emitter.SendMessage("SetMechanicalSound", mechClip, SendMessageOptions.DontRequireReceiver);
+                                if (activeProfile.SteamSettings.SteamSounds != null && activeProfile.SteamSettings.SteamSounds.Length > 0)
+                                {
+                                    AudioClip steamClip = activeProfile.SteamSettings.SteamSounds[random.Next(activeProfile.SteamSettings.SteamSounds.Length)];
+                                    controller.SetSteamSound(steamClip);
+                                }
+
+                                if (activeProfile.SteamSettings.MechanicalSounds != null && activeProfile.SteamSettings.MechanicalSounds.Length > 0)
+                                {
+                                    AudioClip mechClip = activeProfile.SteamSettings.MechanicalSounds[random.Next(activeProfile.SteamSettings.MechanicalSounds.Length)];
+                                    controller.SetMechanicalSound(mechClip);
+                                }
                             }
                         }
                     }

--- a/Assets/Scripts/VFX/SteamEmitterController.cs
+++ b/Assets/Scripts/VFX/SteamEmitterController.cs
@@ -1,0 +1,118 @@
+using UnityEngine;
+
+namespace RollABall.VFX
+{
+    /// <summary>
+    /// Controls a steam emitter using profile settings.
+    /// </summary>
+    [AddComponentMenu("Roll-a-Ball/VFX/Steam Emitter Controller")]
+    public class SteamEmitterController : MonoBehaviour
+    {
+        [SerializeField] private SteamEmitterProfile profile;
+        [SerializeField] private ParticleSystem steamParticles;
+        [SerializeField] private float playerEffectRadius = 3f;
+
+        private ParticleSystem.EmissionModule emission;
+        private Transform playerTransform;
+        private Rigidbody playerRigidbody;
+        private AudioSource audioSource;
+
+        /// <summary>
+        /// Initializes the emitter with a profile.
+        /// </summary>
+        public void Init(SteamEmitterProfile settings)
+        {
+            ApplyProfile(settings);
+        }
+
+        /// <summary>
+        /// Apply settings from a SteamEmitterProfile.
+        /// </summary>
+        public void ApplyProfile(SteamEmitterProfile settings)
+        {
+            profile = settings;
+            if (profile == null)
+                return;
+
+            if (!steamParticles)
+                steamParticles = GetComponentInChildren<ParticleSystem>();
+
+            if (steamParticles)
+            {
+                emission = steamParticles.emission;
+                emission.rateOverTime = profile.BaseEmissionRate;
+            }
+        }
+
+        /// <summary>
+        /// Set steam audio clip.
+        /// </summary>
+        public void SetSteamSound(AudioClip clip)
+        {
+            if (!clip) return;
+            EnsureAudioSource();
+            audioSource.PlayOneShot(clip);
+        }
+
+        /// <summary>
+        /// Set mechanical audio clip.
+        /// </summary>
+        public void SetMechanicalSound(AudioClip clip)
+        {
+            if (!clip) return;
+            EnsureAudioSource();
+            audioSource.PlayOneShot(clip);
+        }
+
+        private void Awake()
+        {
+            EnsurePlayer();
+            EnsureAudioSource();
+            if (profile != null)
+                ApplyProfile(profile);
+        }
+
+        private void FixedUpdate()
+        {
+            // Steam emitter affects player movement
+            if (profile == null || !profile.AffectPlayerMovement)
+                return;
+            if (!playerTransform)
+                EnsurePlayer();
+            if (!playerRigidbody) return;
+
+            float distance = Vector3.Distance(transform.position, playerTransform.position);
+            if (distance <= playerEffectRadius)
+            {
+                // Apply wind force
+                Vector3 direction = transform.up;
+                playerRigidbody.AddForce(direction * profile.WindForce, ForceMode.Force);
+            }
+        }
+
+        private void EnsurePlayer()
+        {
+            if (playerTransform) return;
+            GameObject player = GameObject.FindGameObjectWithTag("Player");
+            if (player)
+            {
+                playerTransform = player.transform;
+                playerRigidbody = player.GetComponent<Rigidbody>();
+            }
+        }
+
+        private void EnsureAudioSource()
+        {
+            if (audioSource) return;
+            audioSource = GetComponent<AudioSource>();
+            if (!audioSource)
+                audioSource = gameObject.AddComponent<AudioSource>();
+            audioSource.spatialBlend = 1f;
+        }
+
+        /// <summary>
+        /// Returns true if this emitter influences player movement.
+        /// </summary>
+        public bool HasMovementInfluence => profile != null && profile.AffectPlayerMovement;
+    }
+}


### PR DESCRIPTION
## Summary
- add `SteamEmitterController` to apply `SteamEmitterProfile` at runtime
- push wind force on the player when close to an emitter
- initialize emitters with profile data from `LevelGenerator`
- log how many emitters affect the player in debug mode

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68873c74dd988324b4fa342aa6f1ebe4