### PR TITLE
Add interactive gates and switches

### DIFF
--- a/Assets/Scripts/Environment/GateController.cs
+++ b/Assets/Scripts/Environment/GateController.cs
@@ -1,0 +1,37 @@
+using UnityEngine;
+
+namespace RollABall.Environment
+{
+    /// <summary>
+    /// Simple gate controller that can be opened via script.
+    /// </summary>
+    [AddComponentMenu("Roll-a-Ball/Environment/Gate Controller")]
+    public class GateController : MonoBehaviour
+    {
+        [SerializeField] private GameObject gateObject;
+        private bool opened = false;
+
+        private void Awake()
+        {
+            if (!gateObject)
+                gateObject = gameObject;
+        }
+
+        /// <summary>
+        /// Opens the gate by disabling visuals and collider.
+        /// </summary>
+        public void TriggerOpen()
+        {
+            if (opened) return;
+            opened = true;
+
+            if (gateObject)
+            {
+                var col = gateObject.GetComponent<Collider>();
+                if (col) col.enabled = false;
+                var rend = gateObject.GetComponent<Renderer>();
+                if (rend) rend.enabled = false;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Environment/SwitchTrigger.cs
+++ b/Assets/Scripts/Environment/SwitchTrigger.cs
@@ -1,0 +1,29 @@
+using UnityEngine;
+
+namespace RollABall.Environment
+{
+    /// <summary>
+    /// Trigger component that opens a connected gate when the player enters.
+    /// </summary>
+    [AddComponentMenu("Roll-a-Ball/Environment/Switch Trigger")]
+    public class SwitchTrigger : MonoBehaviour
+    {
+        [SerializeField] private GateController connectedGate;
+        private bool activated = false;
+
+        public void SetGate(GateController gate)
+        {
+            connectedGate = gate;
+        }
+
+        private void OnTriggerEnter(Collider other)
+        {
+            if (activated) return;
+            if (other.CompareTag("Player"))
+            {
+                connectedGate?.TriggerOpen();
+                activated = true;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create `GateController` and `SwitchTrigger` scripts
- place gate/switch pairs in `LevelGenerator` when profile enables interactive gates
- visualize gate connections in gizmos

## Testing
- `bash dev_scripts/run_stress_tests.sh` *(fails: `Unity command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68873e37235483248ebd63a8085f0eb9