### PR TITLE
Add gate unlock by collectibles

### DIFF
--- a/Assets/Scripts/Environment/GateController.cs
+++ b/Assets/Scripts/Environment/GateController.cs
@@ -9,7 +9,24 @@ namespace RollABall.Environment
     public class GateController : MonoBehaviour
     {
         [SerializeField] private GameObject gateObject;
+        [SerializeField] private bool requiresAllCollectibles = false; // Gate requires all collectibles to be opened
+        [SerializeField] private bool requiresSwitchTrigger = true;
+        [SerializeField] private bool debugMode = false;
+
+        public bool RequiresAllCollectibles
+        {
+            get => requiresAllCollectibles;
+            set => requiresAllCollectibles = value;
+        }
+
+        public bool RequiresSwitchTrigger
+        {
+            get => requiresSwitchTrigger;
+            set => requiresSwitchTrigger = value;
+        }
+
         private bool opened = false;
+        private bool switchActivated = false;
 
         private void Awake()
         {
@@ -17,12 +34,48 @@ namespace RollABall.Environment
                 gateObject = gameObject;
         }
 
+        private void Start()
+        {
+            if (requiresAllCollectibles && LevelManager.Instance)
+            {
+                LevelManager.Instance.OnCollectibleCountChanged += OnCollectibleCountChanged;
+
+                // Check current state in case collectibles are already gathered
+                if (LevelManager.Instance.CollectiblesRemaining == 0 && !requiresSwitchTrigger)
+                {
+                    OnCollectibleCountChanged(0, LevelManager.Instance.TotalCollectibles);
+                }
+            }
+        }
+
+        private void OnDestroy()
+        {
+            if (requiresAllCollectibles && LevelManager.Instance)
+            {
+                LevelManager.Instance.OnCollectibleCountChanged -= OnCollectibleCountChanged;
+            }
+        }
+
         /// <summary>
         /// Opens the gate by disabling visuals and collider.
         /// </summary>
-        public void TriggerOpen()
+        public void TriggerOpen(bool fromSwitch = false)
         {
             if (opened) return;
+
+            if (fromSwitch)
+                switchActivated = true;
+
+            if (requiresSwitchTrigger && !switchActivated)
+                return;
+
+            if (requiresAllCollectibles && LevelManager.Instance && LevelManager.Instance.CollectiblesRemaining > 0)
+            {
+                if (debugMode)
+                    Debug.Log($"Gate '{name}' waiting for collectibles. Remaining: {LevelManager.Instance.CollectiblesRemaining}");
+                return;
+            }
+
             opened = true;
 
             if (gateObject)
@@ -31,6 +84,23 @@ namespace RollABall.Environment
                 if (col) col.enabled = false;
                 var rend = gateObject.GetComponent<Renderer>();
                 if (rend) rend.enabled = false;
+            }
+
+            if (debugMode)
+            {
+                string reason = fromSwitch ? "switch" : "collectibles";
+                Debug.Log($"Gate '{name}' opened via {reason}.");
+            }
+        }
+
+        private void OnCollectibleCountChanged(int remaining, int total)
+        {
+            if (remaining <= 0)
+            {
+                if (debugMode)
+                    Debug.Log($"Gate '{name}' opening due to collectibles collected.");
+
+                TriggerOpen();
             }
         }
     }

--- a/Assets/Scripts/Environment/SwitchTrigger.cs
+++ b/Assets/Scripts/Environment/SwitchTrigger.cs
@@ -21,7 +21,7 @@ namespace RollABall.Environment
             if (activated) return;
             if (other.CompareTag("Player"))
             {
-                connectedGate?.TriggerOpen();
+                connectedGate?.TriggerOpen(true);
                 activated = true;
             }
         }

--- a/Assets/Scripts/Generators/LevelGenerator.cs
+++ b/Assets/Scripts/Generators/LevelGenerator.cs
@@ -1186,6 +1186,33 @@ public class LevelGenerator : MonoBehaviour
         int pairCount = Mathf.Max(1, Mathf.RoundToInt(walkableTiles.Count * activeProfile.InteractiveGateDensity));
         float tileSize = activeProfile.TileSize;
 
+        // Place a gate near the goal that opens after collecting all items
+        if (walkableTiles.Count > 0)
+        {
+            Vector2Int goalGateTile = goalPosition;
+            List<Vector2Int> nearGoal = new List<Vector2Int>();
+            foreach (Vector2Int pos in walkableTiles)
+            {
+                if (Vector2Int.Distance(pos, goalPosition) <= 2)
+                    nearGoal.Add(pos);
+            }
+            if (nearGoal.Count > 0)
+                goalGateTile = nearGoal[random.Next(nearGoal.Count)];
+
+            Vector3 gatePos = new Vector3(goalGateTile.x * tileSize, 0, goalGateTile.y * tileSize);
+            GameObject gatePrefab = activeProfile.InteractiveGatePrefabs[random.Next(activeProfile.InteractiveGatePrefabs.Length)];
+            GameObject gateObj = Instantiate(gatePrefab, gatePos, Quaternion.identity, levelContainer);
+            var gateCtrl = gateObj.GetComponent<RollABall.Environment.GateController>();
+            if (!gateCtrl)
+                gateCtrl = gateObj.AddComponent<RollABall.Environment.GateController>();
+
+            gateCtrl.RequiresAllCollectibles = true; // Gate requires all collectibles to be opened
+            gateCtrl.RequiresSwitchTrigger = false;
+
+            if (showGenerationDebug)
+                Debug.Log($"Placed goal gate at {gatePos}");
+        }
+
         for (int i = 0; i < pairCount; i++)
         {
             if (walkableTiles.Count < 2)


### PR DESCRIPTION
## Summary
- extend GateController with options for switch and collectible requirements
- subscribe to LevelManager events to open gates when collectibles are gathered
- adjust SwitchTrigger to call updated API
- spawn a gate near the goal that requires all collectibles to be collected

## Testing
- `bash dev_scripts/run_stress_tests.sh` *(fails: Unity not found)*

------
https://chatgpt.com/codex/tasks/task_e_688740681d588324a2307599d9c578c1