### PR TITLE
Add hybrid generation modes with dynamic selection

### DIFF
--- a/Assets/Editor/ProjectCleanupAndFix.cs
+++ b/Assets/Editor/ProjectCleanupAndFix.cs
@@ -110,7 +110,7 @@ namespace RollABall.Editor
             // Create or update profiles
             CreateOrUpdateProfile("EasyProfile", "Easy", 8, 5, 0.1f, LevelGenerationMode.Simple, folderPath);
             CreateOrUpdateProfile("MediumProfile", "Medium", 12, 10, 0.2f, LevelGenerationMode.Maze, folderPath);
-            CreateOrUpdateProfile("HardProfile", "Hard", 16, 15, 0.4f, LevelGenerationMode.Hybrid, folderPath);
+            CreateOrUpdateProfile("HardProfile", "Hard", 16, 15, 0.4f, LevelGenerationMode.HybridMazeOpen, folderPath);
 
             Debug.Log("LevelProfiles created successfully!");
         }


### PR DESCRIPTION
## Summary
- introduce `HybridMazeOpen` and `HybridOrganicPath` level generation modes
- add optional dynamic generation mode selection in `LevelProfile`
- implement hybrid layouts and integrate into `LevelGenerator`
- adjust project setup script for new enum

## Testing
- `bash dev_scripts/run_stress_tests.sh` *(fails: Unity command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688746ab599c83249ebcf99daa456cb9