### PR TITLE
Implement dynamic density adjustments

### DIFF
--- a/Assets/Scripts/Generators/LevelGenerator.cs
+++ b/Assets/Scripts/Generators/LevelGenerator.cs
@@ -319,9 +319,14 @@ public class LevelGenerator : MonoBehaviour
 
         usedGenerationMode = activeProfile.GetAdaptiveGenerationMode(seed);
 
+        activeProfile.AdjustDensitiesForMode();
+
         if (showGenerationDebug)
         {
             Debug.Log($"Generating level with seed: {seed} using mode {usedGenerationMode}");
+            Debug.Log($"Densities - Obstacles: {activeProfile.ObstacleDensity}, " +
+                      $"Rotating: {activeProfile.RotatingObstacleDensity}, Steam: {activeProfile.SteamEmitterDensity}, " +
+                      $"Gates: {activeProfile.InteractiveGateDensity}");
         }
 
         // Setup containers

--- a/Assets/Scripts/Generators/LevelProfile.cs
+++ b/Assets/Scripts/Generators/LevelProfile.cs
@@ -226,8 +226,34 @@ public class LevelProfile : ScriptableObject
         scaledProfile.rotatingObstacleDensity = Mathf.Clamp01(rotatingObstacleDensity * difficultyMultiplier);
         scaledProfile.movingPlatformDensity = Mathf.Clamp01(movingPlatformDensity * difficultyMultiplier);
         scaledProfile.steamEmitterDensity = Mathf.Clamp01(steamEmitterDensity * difficultyMultiplier);
-        
+
         return scaledProfile;
+    }
+
+    // Automatically adjust densities based on generation mode
+    public void AdjustDensitiesForMode()
+    {
+        switch (generationMode)
+        {
+            case LevelGenerationMode.Maze:
+                obstacleDensity = 0.25f + 0.05f * difficultyLevel;
+                rotatingObstacleDensity = 0.08f;
+                break;
+            case LevelGenerationMode.Organic:
+                obstacleDensity = 0.45f;
+                steamEmitterDensity = 0.12f;
+                rotatingObstacleDensity = 0.03f;
+                break;
+            case LevelGenerationMode.HybridMazeOpen:
+                obstacleDensity = 0.3f;
+                rotatingObstacleDensity = 0.06f;
+                interactiveGateDensity = 0.04f;
+                break;
+            case LevelGenerationMode.HybridOrganicPath:
+                obstacleDensity = 0.4f;
+                steamEmitterDensity = 0.08f;
+                break;
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- add `AdjustDensitiesForMode` to `LevelProfile` for setting densities automatically
- call new method during generation initialization and print debug values

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688749cb4eb883248b8ec58f176d30f1