### PR TITLE
Add duplication annotations and migration plan

### DIFF
--- a/Assets/Editor/CleanRollABallMenu.cs
+++ b/Assets/Editor/CleanRollABallMenu.cs
@@ -8,6 +8,7 @@ namespace RollABall.Editor
     /// Sauberes und aktuelles Roll-a-Ball Editor Menu
     /// Entfernt alle obsoleten Funktionen und bietet nur noch relevante Tools
     /// </summary>
+    // TODO-DUPLICATE#3: Funktional identisch mit RollABallMenuIntegration.cs und RollABallControlPanelRestorer.cs. Bitte vereinheitlichen oder entfernen.
     public class CleanRollABallMenu : EditorWindow
     {
         private Vector2 scrollPosition;

--- a/Assets/Editor/ObsoleteAPIBatchFixer.cs
+++ b/Assets/Editor/ObsoleteAPIBatchFixer.cs
@@ -5,6 +5,7 @@ using System.Text.RegularExpressions;
 
 namespace RollABall.Editor
 {
+    // TODO-DUPLICATE#2: Funktional identisch mit QuickAPIBatchFixer.cs und QuickAPIFix.cs. Bitte vereinheitlichen oder entfernen.
     public class ObsoleteAPIBatchFixer
     {
         [MenuItem("Roll-a-Ball/⚡ Batch Fix Obsolete APIs", priority = 5)]

--- a/Assets/Editor/QuickAPIBatchFixer.cs
+++ b/Assets/Editor/QuickAPIBatchFixer.cs
@@ -9,6 +9,7 @@ namespace RollABall.Editor
     /// Simple batch fixer for deprecated Unity API calls
     /// Focuses on the most common warnings in Unity 6.1
     /// </summary>
+    // TODO-DUPLICATE#2: Funktional identisch mit ObsoleteAPIBatchFixer.cs und QuickAPIFix.cs. Bitte vereinheitlichen oder entfernen.
     public class QuickAPIBatchFixer : EditorWindow
     {
         [MenuItem("Roll-a-Ball/Fix Tools/Quick API Batch Fix")]

--- a/Assets/Editor/RollABallControlPanelRestorer.cs
+++ b/Assets/Editor/RollABallControlPanelRestorer.cs
@@ -6,6 +6,7 @@ using System.IO;
 
 namespace RollABall.Editor
 {
+    // TODO-DUPLICATE#3: Funktional identisch mit CleanRollABallMenu.cs und RollABallMenuIntegration.cs. Bitte vereinheitlichen oder entfernen.
     public class RollABallControlPanelRestorer : EditorWindow
     {
         private Vector2 scrollPosition;

--- a/Assets/Editor/RollABallMenuIntegration.cs
+++ b/Assets/Editor/RollABallMenuIntegration.cs
@@ -7,6 +7,7 @@ using UnityEngine.SceneManagement;
 /// Unity Editor Menu Integration for Roll-a-Ball Fix Tools
 /// Provides easy access to all repair functions via Unity menu
 /// </summary>
+// TODO-DUPLICATE#3: Funktional identisch mit CleanRollABallMenu.cs und RollABallControlPanelRestorer.cs. Bitte vereinheitlichen oder entfernen.
 public class RollABallMenuIntegration : EditorWindow
 {
     private Vector2 scrollPosition;

--- a/Assets/Scripts/Editor/ControlPanelAPIFix.cs
+++ b/Assets/Scripts/Editor/ControlPanelAPIFix.cs
@@ -6,6 +6,7 @@ using System.Text.RegularExpressions;
 /// <summary>
 /// Control Panel API Fix - Fix remaining FindObjectOfType calls in RollABallControlPanel
 /// </summary>
+// TODO-DUPLICATE#2: Funktional identisch mit QuickAPIFix.cs. Bitte vereinheitlichen oder entfernen.
 public class ControlPanelAPIFix
 {
     [MenuItem("Roll-a-Ball/🔧 Fix Control Panel APIs")]

--- a/Assets/Scripts/Editor/FinalAPICleanup.cs
+++ b/Assets/Scripts/Editor/FinalAPICleanup.cs
@@ -6,6 +6,7 @@ using System.Text.RegularExpressions;
 /// <summary>
 /// Final API Cleanup - Fix remaining Object.FindObjectOfType calls
 /// </summary>
+// TODO-DUPLICATE#2: Funktional identisch mit QuickAPIFix.cs. Bitte vereinheitlichen oder entfernen.
 public class FinalAPICleanup
 {
     [MenuItem("Roll-a-Ball/🎯 Final API Cleanup")]

--- a/Assets/Scripts/Editor/QuickAPIFix.cs
+++ b/Assets/Scripts/Editor/QuickAPIFix.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 /// <summary>
 /// Quick API Fix Runner - Executes the Unity 6.1 API fixes automatically
 /// </summary>
+// TODO-DUPLICATE#2: Funktional identisch mit QuickAPIBatchFixer.cs und ObsoleteAPIBatchFixer.cs. Bitte vereinheitlichen oder entfernen.
 public class QuickAPIFix
 {
     [MenuItem("Roll-a-Ball/🚀 Quick Fix All APIs")]

--- a/Assets/_LegacyScripts/LevelProfileCreator.cs
+++ b/Assets/_LegacyScripts/LevelProfileCreator.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 using UnityEditor;
 #endif
 // TODO-REMOVE#2: Obsolete setup script – no longer needed and may corrupt current data
+// TODO-DUPLICATE#1: Funktional identisch mit LevelSetupHelper.cs. Bitte vereinheitlichen oder entfernen.
 
 /// <summary>
 /// Utility-Klasse zum Erstellen der Standard-LevelProfile Assets

--- a/Assets/_LegacyScripts/LevelSetupHelper.cs
+++ b/Assets/_LegacyScripts/LevelSetupHelper.cs
@@ -6,6 +6,7 @@ using UnityEditor.SceneManagement;
 using System.IO;
 #endif
 // TODO-REMOVE#1: Obsolete setup script – no longer needed and may corrupt current data
+// TODO-DUPLICATE#1: Funktional identisch mit LevelProfileCreator.cs. Bitte vereinheitlichen oder entfernen.
 
 /// <summary>
 /// Helper-Klasse zum automatischen Setup des prozeduralen Levelgenerierungssystems

--- a/Duplicates_Index.md
+++ b/Duplicates_Index.md
@@ -1,0 +1,10 @@
+### Duplicates & Redundancy Index
+
+| ID | Typ | Pfad oder Datei | Duplikat von | Empfehlung |
+| --- | --- | --- | --- | --- |
+| DUPLICATE#1 | Script | Assets/_LegacyScripts/LevelProfileCreator.cs | Assets/_LegacyScripts/LevelSetupHelper.cs | zusammenführen |
+| DUPLICATE#2 | Script | Assets/Editor/QuickAPIBatchFixer.cs | Assets/Scripts/Editor/QuickAPIFix.cs, Assets/Editor/ObsoleteAPIBatchFixer.cs, Assets/Scripts/Editor/FinalAPICleanup.cs | zusammenführen |
+| DUPLICATE#3 | Script | Assets/Editor/CleanRollABallMenu.cs | Assets/Editor/RollABallMenuIntegration.cs, Assets/Editor/RollABallControlPanelRestorer.cs | zusammenführen |
+| DUPLICATE#4 | Asset `.asset` | Assets/Resources/LevelProfiles/EasyProfile.asset | Assets/ScriptableObjects/EasyProfile.asset | nur eines behalten |
+| DUPLICATE#5 | Asset `.asset` | Assets/Resources/LevelProfiles/MediumProfile.asset | Assets/ScriptableObjects/MediumProfile.asset | nur eines behalten |
+| DUPLICATE#6 | Asset `.asset` | Assets/Resources/LevelProfiles/HardProfile.asset | Assets/ScriptableObjects/HardProfile.asset | nur eines behalten |

--- a/Merge_Migration_Plan.md
+++ b/Merge_Migration_Plan.md
@@ -1,0 +1,31 @@
+### Merge & Migration Plan
+
+#### DUPLICATE#1 – `LevelProfileCreator.cs` & `LevelSetupHelper.cs`
+**Empfehlung:**
+Funktionen zur Erstellung von LevelProfiles zentral in einer Utility-Klasse `LevelProfileUtility.cs` sammeln. Menüeinträge und automatische Setup-Aufrufe nur dort definieren.
+**Migration:**
+* `LevelProfileCreator.cs` und `LevelSetupHelper.cs` entfernen
+* Neue Klasse `LevelProfileUtility` unter `Assets/Scripts/Generators/` anlegen
+* Aufrufe in `RollABallControlPanel.cs` anpassen, um `LevelProfileUtility.CreateDefaultProfiles()` zu nutzen
+
+#### DUPLICATE#2 – API Fixer Skripte
+**Empfehlung:**
+`QuickAPIBatchFixer`, `ObsoleteAPIBatchFixer`, `QuickAPIFix` und `FinalAPICleanup` in ein einziges Skript `UnifiedAPIFixer.cs` konsolidieren. Spezialfunktionen wie `ControlPanelAPIFix` in dieselbe Klasse als Methoden aufnehmen.
+**Migration:**
+* Alle genannten Fixer-Skripte löschen
+* Neues Werkzeug `UnifiedAPIFixer` im Menü `Roll-a-Ball/Fix Tools` registrieren
+* Verweise in Dokumentation oder Build-Skripten aktualisieren
+
+#### DUPLICATE#3 – Editor Menüfenster
+**Empfehlung:**
+`CleanRollABallMenu`, `RollABallMenuIntegration` und `RollABallControlPanelRestorer` zu einem einzigen übersichtlichen Editorfenster zusammenführen.
+**Migration:**
+* Gemeinsame Funktionen in `CleanRollABallMenu` belassen und andere Fenster entfernen
+* Menüeinträge anpassen, sodass nur noch ein Control Panel existiert
+
+#### DUPLICATE#4–#6 – LevelProfile Assets
+**Empfehlung:**
+Nur die Assets im Ordner `Assets/ScriptableObjects/` verwenden. Die Kopien in `Resources/LevelProfiles` entfernen.
+**Migration:**
+* Alle `Resources.Load<LevelProfile>`-Aufrufe auf direkte Referenzen oder Addressables umstellen
+* Assets in `Resources/LevelProfiles` löschen, danach Verweise prüfen


### PR DESCRIPTION
## Summary
- mark duplicate scripts with TODO-DUPLICATE comments
- index redundant scripts and assets in `Duplicates_Index.md`
- add `Merge_Migration_Plan.md` with consolidation advice

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68875a7f51c08324a8146894fb2ab776