### PR TITLE
Fix collectible rotation around local axis

### DIFF
--- a/Assets/Prefabs/CollectiblePrefab.prefab
+++ b/Assets/Prefabs/CollectiblePrefab.prefab
@@ -12,6 +12,7 @@ GameObject:
   - component: {fileID: 1690839340638707025}
   - component: {fileID: 6433723627022814060}
   - component: {fileID: 353597688086778592}
+  - component: {fileID: 2659470982871370921}
   m_Layer: 0
   m_Name: CollectiblePrefab
   m_TagString: Collectible
@@ -108,3 +109,38 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
+--- !u!114 &2659470982871370921
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4044417440240046019}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 13c787ff32ca807ce8e64436f33a098c, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  collectibleData:
+    itemName: Collectible
+    itemType: standard
+    pointValue: 1
+    isCollected: 0
+    rotateObject: 1
+    rotationSpeed: 90
+    enablePulseEffect: 1
+    pulseIntensity: 0.1
+    pulseSpeed: 2
+    collectSound: {fileID: 0}
+    soundVolume: 1
+  renderers: []
+  collectEffect: {fileID: 0}
+  itemLight: {fileID: 0}
+  triggerCollider: {fileID: 0}
+  autoSetupCollider: 1
+  OnCollected:
+    m_PersistentCalls:
+      m_Calls: []
+  OnCollectedWithData:
+    m_PersistentCalls:
+      m_Calls: []

--- a/Assets/Scenes/Level1.unity
+++ b/Assets/Scenes/Level1.unity
@@ -198,7 +198,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 92568890}
-  - component: {fileID: 92568891}
   m_Layer: 0
   m_Name: Collectible
   m_TagString: Collectible
@@ -226,41 +225,6 @@ Transform:
   - {fileID: 405430383}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &92568891
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 92568889}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 13c787ff32ca807ce8e64436f33a098c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  collectibleData:
-    itemName: Collectible
-    itemType: standard
-    pointValue: 1
-    isCollected: 0
-    rotateObject: 1
-    rotationSpeed: 90
-    enablePulseEffect: 1
-    pulseIntensity: 0.1
-    pulseSpeed: 2
-    collectSound: {fileID: 0}
-    soundVolume: 1
-  renderers: []
-  collectEffect: {fileID: 0}
-  itemLight: {fileID: 0}
-  triggerCollider: {fileID: 0}
-  autoSetupCollider: 1
-  OnCollected:
-    m_PersistentCalls:
-      m_Calls: []
-  OnCollectedWithData:
-    m_PersistentCalls:
-      m_Calls: []
 --- !u!1 &93226910
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Level2.unity
+++ b/Assets/Scenes/Level2.unity
@@ -2774,7 +2774,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1742414280}
-  - component: {fileID: 1742414281}
   m_Layer: 0
   m_Name: Collectible
   m_TagString: Collectible
@@ -2805,41 +2804,6 @@ Transform:
   - {fileID: 659123493}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1742414281
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1742414279}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 13c787ff32ca807ce8e64436f33a098c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  collectibleData:
-    itemName: Collectible
-    itemType: standard
-    pointValue: 1
-    isCollected: 0
-    rotateObject: 1
-    rotationSpeed: 90
-    enablePulseEffect: 1
-    pulseIntensity: 0.1
-    pulseSpeed: 2
-    collectSound: {fileID: 0}
-    soundVolume: 1
-  renderers: []
-  collectEffect: {fileID: 0}
-  itemLight: {fileID: 0}
-  triggerCollider: {fileID: 0}
-  autoSetupCollider: 1
-  OnCollected:
-    m_PersistentCalls:
-      m_Calls: []
-  OnCollectedWithData:
-    m_PersistentCalls:
-      m_Calls: []
 --- !u!1 &1764880525
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Level3.unity
+++ b/Assets/Scenes/Level3.unity
@@ -1725,7 +1725,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1450058656}
-  - component: {fileID: 1450058657}
   m_Layer: 0
   m_Name: Collectible
   m_TagString: Collectible
@@ -1760,41 +1759,6 @@ Transform:
   - {fileID: 1260366144}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1450058657
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1450058655}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 13c787ff32ca807ce8e64436f33a098c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  collectibleData:
-    itemName: Collectible
-    itemType: standard
-    pointValue: 1
-    isCollected: 0
-    rotateObject: 1
-    rotationSpeed: 90
-    enablePulseEffect: 1
-    pulseIntensity: 0.1
-    pulseSpeed: 2
-    collectSound: {fileID: 0}
-    soundVolume: 1
-  renderers: []
-  collectEffect: {fileID: 0}
-  itemLight: {fileID: 0}
-  triggerCollider: {fileID: 0}
-  autoSetupCollider: 1
-  OnCollected:
-    m_PersistentCalls:
-      m_Calls: []
-  OnCollectedWithData:
-    m_PersistentCalls:
-      m_Calls: []
 --- !u!1001 &1496142296
 PrefabInstance:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## Summary
- add `CollectibleController` component directly to `CollectiblePrefab`
- remove stray `CollectibleController` instances from parent objects in the main scenes

Each collectible now rotates only around its own local axis.

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6888d55fbe1c8324a7ce114df2e08531