### PR TITLE
Refactor respawn and add TODO review markers

### DIFF
--- a/Assets/Scripts/AchievementSystem.cs
+++ b/Assets/Scripts/AchievementSystem.cs
@@ -544,6 +544,7 @@ public class AchievementSystem : MonoBehaviour
         GameObject notification = Instantiate(achievementNotificationPrefab, notificationParent);
         
         // Configure notification (this would depend on your notification prefab structure)
+        // TODO: Implement AchievementNotificationUI to display icon and text
         // notification.GetComponent<AchievementNotificationUI>().Setup(achievement);
         
         // Wait for notification duration
@@ -605,6 +606,8 @@ public class AchievementSystem : MonoBehaviour
     private void SaveAchievementProgress()
     {
         if (SaveSystem.Instance?.CurrentSave == null) return;
+
+        // TODO: Implement cross-device cloud sync of achievements
         
         var save = SaveSystem.Instance.CurrentSave;
         save.achievementProgress.Clear();

--- a/Assets/Scripts/AudioManager.cs
+++ b/Assets/Scripts/AudioManager.cs
@@ -93,6 +93,8 @@ public class AudioManager : MonoBehaviour
         availableSources = new Queue<AudioSource>();
         allSources = new List<AudioSource>();
 
+        // TODO: Preload sources asynchronously to reduce startup hiccups
+
         // Create main music source if not assigned
         if (!musicSource)
         {

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -373,13 +373,9 @@ public class GameManager : MonoBehaviour
 
         player.transform.position = respawnPosition + Vector3.up * 2f;
         
-        // Reset player velocity
+        // Reset player velocity via helper
         Rigidbody playerRb = player.GetComponent<Rigidbody>();
-        if (playerRb)
-        {
-            playerRb.linearVelocity = Vector3.zero;
-            playerRb.angularVelocity = Vector3.zero;
-        }
+        PhysicsUtils.ResetMotion(playerRb);
 
         // Re-enable player
         player.enabled = true;

--- a/Assets/Scripts/LevelSelectionUI.cs
+++ b/Assets/Scripts/LevelSelectionUI.cs
@@ -463,6 +463,7 @@ public class LevelSelectionUI : MonoBehaviour
         // Update preview image
         if (levelPreviewImage && level.levelIcon)
         {
+            // TODO: Cache sprites and load asynchronously for large levels
             levelPreviewImage.sprite = level.levelIcon;
         }
     }

--- a/Assets/Scripts/Map/MapStartupController.cs
+++ b/Assets/Scripts/Map/MapStartupController.cs
@@ -266,6 +266,7 @@ namespace RollABall.Map
             if (enableSimulationMode)
             {
                 Vector2 coords = new Vector2(latitude, longitude);
+                // TODO: Cache generated maps to avoid repeated downloads
                 StartCoroutine(CreateLevelFromCoordinates(coords));
             }
             else

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -68,6 +68,7 @@ public class PlayerController : MonoBehaviour
     private Coroutine slideCoroutine;
     
     // Input states - LEGACY INPUT SYSTEM
+    // TODO: Replace with new Input System integration
     private Vector2 movementInput;
     private bool jumpPressed;
     private bool flyPressed;
@@ -158,6 +159,7 @@ public class PlayerController : MonoBehaviour
     private void HandleInput()
     {
         // Movement input (WASD / Arrow Keys) - LEGACY INPUT
+        // TODO: Use InputAction bindings from a centralized input manager
         float horizontal = Input.GetAxis("Horizontal");
         float vertical = Input.GetAxis("Vertical");
         movementInput = new Vector2(horizontal, vertical);
@@ -168,6 +170,7 @@ public class PlayerController : MonoBehaviour
         sprintPressed = Input.GetKey(sprintKey);
         
         // Slide input handling - LEGACY INPUT
+        // TODO: Integrate slide action into input manager
         if (Input.GetKeyDown(slideKey))
             StartSlide();
         else if (Input.GetKeyUp(slideKey))

--- a/Assets/Scripts/UIController.cs
+++ b/Assets/Scripts/UIController.cs
@@ -194,6 +194,7 @@ public class UIController : MonoBehaviour
         if (statisticsBackButton) statisticsBackButton.onClick.AddListener(HideStatisticsPanel);
         
         // Subscribe to system events
+        // TODO: Unsubscribe in OnDestroy to avoid memory leaks
         if (SaveSystem.Instance)
         {
             SaveSystem.Instance.OnSaveLoaded += OnSaveLoaded;


### PR DESCRIPTION
## Summary
- reuse PhysicsUtils when respawning the player
- mark legacy input handling for migration
- flag missing event unsubscriptions and async loading improvements
- note cross-device sync for achievements
- add caching TODOs for map generation and level previews
- hint at asynchronous audio source preload

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6888dfc3d8bc8324b417890a52335cdf