### PR TITLE
Add TODO annotations for maintenance

### DIFF
--- a/Assets/Scripts/AchievementSystem.cs
+++ b/Assets/Scripts/AchievementSystem.cs
@@ -183,6 +183,7 @@ public class AchievementSystem : MonoBehaviour
     
     private void CreateDefaultAchievements()
     {
+        // TODO: Load achievement definitions from external config or ScriptableObject
         allAchievements.Clear();
         
         // General Achievements
@@ -291,7 +292,7 @@ public class AchievementSystem : MonoBehaviour
         }
         
         // Subscribe to player events
-        PlayerController player = FindFirstObjectByType<PlayerController>();
+        PlayerController player = FindFirstObjectByType<PlayerController>(); // TODO: Cache reference to avoid repeated searches
         if (player)
         {
             player.OnGroundedChanged += OnPlayerGrounded;
@@ -716,5 +717,6 @@ public class AchievementSystem : MonoBehaviour
     {
         // Save progress before destruction
         SaveAchievementProgress();
+        // TODO: Unsubscribe from game events to prevent memory leaks
     }
 }

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -29,7 +29,7 @@ public class GameManager : MonoBehaviour
     [Header("Game Settings")]
     [SerializeField] private bool debugMode = false;
     [SerializeField] private float gameTimeScale = 1f;
-    [SerializeField] private KeyCode pauseKey = KeyCode.Escape;
+    [SerializeField] private KeyCode pauseKey = KeyCode.Escape; // TODO: Expose pauseKey in settings menu
     [SerializeField] private KeyCode restartKey = KeyCode.R;
 
     [Header("Player Reference")]
@@ -403,7 +403,7 @@ public class GameManager : MonoBehaviour
         while (currentState == GameState.Playing)
         {
             UpdateStatistics();
-            yield return new WaitForSeconds(0.1f); // Update 10 times per second
+            yield return new WaitForSeconds(0.1f); // TODO: Expose update interval in inspector
         }
     }
 

--- a/Assets/Scripts/Map/AddressResolver.cs
+++ b/Assets/Scripts/Map/AddressResolver.cs
@@ -97,10 +97,12 @@ namespace RollABall.Map
         private IEnumerator ResolveAddressCoroutine(string address)
         {
             Debug.Log($"[AddressResolver] Resolving address: {address}");
-            
+
             // Build Nominatim search URL
             string encodedAddress = UnityWebRequest.EscapeURL(address);
             string geocodeUrl = $"{nominatimBaseUrl}/search?q={encodedAddress}&format=json&limit=1&addressdetails=1&extratags=1";
+
+            // TODO: Cache geocode responses to minimize network requests
             
             using (UnityWebRequest request = UnityWebRequest.Get(geocodeUrl))
             {

--- a/Assets/Scripts/Map/MapGenerator.cs
+++ b/Assets/Scripts/Map/MapGenerator.cs
@@ -705,7 +705,7 @@ namespace RollABall.Map
                             Random.Range(-5f, 5f),
                             1f, // Above ground
                             Random.Range(-5f, 5f)
-                        );
+                        ); // TODO: Expose offset range as serialized fields
                         
                         positions.Add(buildingPos + offset);
                     }
@@ -733,6 +733,7 @@ namespace RollABall.Map
         private Vector3 FindOptimalGoalPosition()
         {
             // Place goal at the center of the largest building or at map center
+            // TODO: Consider using pathfinding analysis to choose a challenging location
             Vector3 goalPos = currentMapData.GetWorldCenter();
             
             if (currentMapData.buildings.Count > 0)

--- a/Assets/Scripts/Map/MapGeneratorBatched.cs
+++ b/Assets/Scripts/Map/MapGeneratorBatched.cs
@@ -111,6 +111,7 @@ namespace RollABall.Map
         {
             // Road collections by material type
             roadMeshesByMaterial.Clear();
+            // TODO: Replace string keys with enum to avoid typos
             roadMeshesByMaterial["motorway"] = new List<CombineInstance>();
             roadMeshesByMaterial["primary"] = new List<CombineInstance>();
             roadMeshesByMaterial["secondary"] = new List<CombineInstance>();

--- a/Assets/Scripts/Map/MapStartupController.cs
+++ b/Assets/Scripts/Map/MapStartupController.cs
@@ -31,14 +31,14 @@ namespace RollABall.Map
         [Header("Endless Mode")]
         [SerializeField] private string[] endlessModeAddresses = {
             "Leipzig, Germany",
-            "Berlin, Germany", 
+            "Berlin, Germany",
             "Munich, Germany",
             "Hamburg, Germany",
             "Dresden, Germany",
             "Cologne, Germany",
             "Frankfurt, Germany",
             "Stuttgart, Germany"
-        };
+        }; // TODO: Load endless mode addresses from external file
         
         [Header("Fallback System")]
         [SerializeField] private GameObject fallbackLevelPrefab;

--- a/Assets/Scripts/UIController.cs
+++ b/Assets/Scripts/UIController.cs
@@ -310,7 +310,7 @@ public class UIController : MonoBehaviour
             }
             else
             {
-                lastPlayedText.text = "New Game";
+                lastPlayedText.text = "New Game"; // TODO: Localize UI strings via a localization system
             }
         }
     }
@@ -816,7 +816,9 @@ public class UIController : MonoBehaviour
     {
         notificationText.text = message;
         notificationPanel.SetActive(true);
-        
+
+        // TODO: Use a pooled notification panel for better performance
+
         yield return new WaitForSeconds(duration);
         
         notificationPanel.SetActive(false);

--- a/TODO_Index.md
+++ b/TODO_Index.md
@@ -44,4 +44,16 @@
 | TODO-OPT#40 | Assets/Scripts/SaveSystem.cs | encryptionKey, Zeile 84 | Schlüssel aus externer Konfiguration laden |
 | TODO-OPT#41 | Assets/Scripts/Map/MapStartupController.cs | LoadMapFromAddress(), Zeile 244 | Adressauflösung asynchron ausführen |
 | TODO-OPT#42 | Assets/Scripts/ProgressionManager.cs | CreateDefaultLevels(), Zeile 203 | Leveldaten extern speichern |
+| TODO-OPT#43 | Assets/Scripts/AchievementSystem.cs | CreateDefaultAchievements(), Zeile 186 | Achievements aus externer Konfiguration laden |
+| TODO-OPT#44 | Assets/Scripts/AchievementSystem.cs | SubscribeToGameEvents(), Zeile 295 | PlayerController-Referenz cachen |
+| TODO-OPT#45 | Assets/Scripts/AchievementSystem.cs | OnDestroy(), Zeile 720 | Von GameEvents abmelden |
+| TODO-OPT#46 | Assets/Scripts/GameManager.cs | pauseKey, Zeile 32 | Pause-Taste im Einstellungsmenü konfigurierbar machen |
+| TODO-OPT#47 | Assets/Scripts/GameManager.cs | TrackStatistics(), Zeile 406 | Update-Intervall einstellbar machen |
+| TODO-OPT#48 | Assets/Scripts/Map/MapGenerator.cs | GenerateCollectiblePositions(), Zeile 708 | Offsetbereich als Felder exposen |
+| TODO-OPT#49 | Assets/Scripts/Map/MapGenerator.cs | FindOptimalGoalPosition(), Zeile 736 | Pfadfindung zur Zielplatzierung nutzen |
+| TODO-OPT#50 | Assets/Scripts/Map/MapStartupController.cs | endlessModeAddresses, Zeile 41 | Adressliste extern speichern |
+| TODO-OPT#51 | Assets/Scripts/Map/AddressResolver.cs | ResolveAddressCoroutine(), Zeile 105 | Geocode-Cache implementieren |
+| TODO-OPT#52 | Assets/Scripts/UIController.cs | UpdateMainMenuUI(), Zeile 313 | UI-Texte lokalisieren |
+| TODO-OPT#53 | Assets/Scripts/UIController.cs | ShowNotificationCoroutine(), Zeile 820 | Notification-Pool verwenden |
+| TODO-OPT#54 | Assets/Scripts/Map/MapGeneratorBatched.cs | InitializeBatchingCollections(), Zeile 114 | String-Keys durch Enum ersetzen |
 


### PR DESCRIPTION
## Summary
- comment on loading achievements from a config
- note caching of player reference and unsubscribing events in AchievementSystem
- expose pause key and stat interval in GameManager
- flag hard-coded collectible offsets and goal placement in MapGenerator
- externalize endless mode addresses
- cache geocode responses in AddressResolver
- add localization reminder and notification pooling in UIController
- hint enum usage for map batching
- record all new TODOs in TODO_Index.md

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6888f1f348f48324803d015bb46a51e5