### PR TITLE
Add maintenance TODOs across scripts

### DIFF
--- a/Assets/Scripts/Environment/MovingPlatform.cs
+++ b/Assets/Scripts/Environment/MovingPlatform.cs
@@ -238,6 +238,7 @@ namespace RollABall.Environment
         /// </summary>
         private float BounceEaseOut(float t)
         {
+            // TODO: Replace hardcoded bounce factors with named constants
             if (t < (1f / 2.75f))
             {
                 return 7.5625f * t * t;
@@ -345,6 +346,7 @@ namespace RollABall.Environment
             if (other.CompareTag("Player"))
             {
                 other.transform.SetParent(transform);
+                // TODO: Handle players with character controllers to avoid parenting issues
             }
         }
         

--- a/Assets/Scripts/Environment/SteampunkGateController.cs
+++ b/Assets/Scripts/Environment/SteampunkGateController.cs
@@ -119,6 +119,7 @@ namespace RollABall.Environment
             
             gameManager = FindFirstObjectByType<GameManager>();
             levelManager = FindFirstObjectByType<LevelManager>();
+            // TODO: Cache manager references via serialized fields to avoid runtime lookup
             
             // Kollider setup
             gateCollider = gateModel?.GetComponent<Collider>();
@@ -660,5 +661,7 @@ namespace RollABall.Environment
             timerInterval = Mathf.Max(1f, timerInterval);
             bounceForce = Mathf.Max(0f, bounceForce);
         }
+
+        // TODO: Implement OnDestroy() to stop coroutines and unregister events
     }
 }

--- a/Assets/Scripts/Generators/LevelGenerator.cs
+++ b/Assets/Scripts/Generators/LevelGenerator.cs
@@ -1458,6 +1458,7 @@ public class LevelGenerator : MonoBehaviour
                                     steamEmitterPositions.Add(pos);
 
                                     // TODO: Apply steam settings if available
+                                    // TODO: Store emitters for pooling instead of destroying on regeneration
                                 }
                             }
                         }

--- a/Assets/Scripts/Map/MapGenerator.cs
+++ b/Assets/Scripts/Map/MapGenerator.cs
@@ -1580,14 +1580,15 @@ namespace RollABall.Map
         private IEnumerator AddSteampunkAtmosphere()
         {
             Debug.Log("[MapGenerator] Adding Steampunk atmosphere...");
-            
+
             // Add ambient lighting adjustments
             RenderSettings.ambientLight = new Color(0.4f, 0.35f, 0.25f);
             RenderSettings.fogColor = new Color(0.5f, 0.4f, 0.3f);
             RenderSettings.fog = true;
             RenderSettings.fogStartDistance = 20f;
             RenderSettings.fogEndDistance = 80f;
-            
+            // TODO: Expose fog parameters via LevelProfile or ScriptableObject
+
             yield return null;
         }
         

--- a/Assets/Scripts/Map/MapStartupController.cs
+++ b/Assets/Scripts/Map/MapStartupController.cs
@@ -507,6 +507,7 @@ namespace RollABall.Map
                 );
                 wall.transform.localScale = new Vector3(2, 2, 2);
             }
+            // TODO: Convert fallback level creation to reusable prefab-based setup
         }
         
         private void PlaceCollectiblesOnMap()

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -525,5 +525,6 @@ public class PlayerController : MonoBehaviour
     {
         if (slideCoroutine != null)
             StopCoroutine(slideCoroutine);
+        // TODO: Unsubscribe from external events to avoid dangling delegates
     }
 }

--- a/Assets/Scripts/UIController.cs
+++ b/Assets/Scripts/UIController.cs
@@ -979,7 +979,9 @@ public class UIController : MonoBehaviour
         else
             ChangeUIState(UIState.MainMenu);
     }
-    
+
+    // TODO: Implement OnDestroy to unsubscribe from all registered events
+
     #endregion
 }
 

--- a/TODO_Index.md
+++ b/TODO_Index.md
@@ -56,4 +56,13 @@
 | TODO-OPT#52 | Assets/Scripts/UIController.cs | UpdateMainMenuUI(), Zeile 313 | UI-Texte lokalisieren |
 | TODO-OPT#53 | Assets/Scripts/UIController.cs | ShowNotificationCoroutine(), Zeile 820 | Notification-Pool verwenden |
 | TODO-OPT#54 | Assets/Scripts/Map/MapGeneratorBatched.cs | InitializeBatchingCollections(), Zeile 114 | String-Keys durch Enum ersetzen |
+| TODO-OPT#55 | Assets/Scripts/Environment/SteampunkGateController.cs | InitializeGate(), Zeile 122 | Manager-Referenzen per Inspector setzen |
+| TODO-OPT#56 | Assets/Scripts/Environment/SteampunkGateController.cs | Zeile 665 | OnDestroy zur Coroutine-Aufräumung einführen |
+| TODO-OPT#57 | Assets/Scripts/Environment/MovingPlatform.cs | BounceEaseOut(), Zeile 241 | Magic Numbers durch Konstanten ersetzen |
+| TODO-OPT#58 | Assets/Scripts/Environment/MovingPlatform.cs | OnTriggerEnter(), Zeile 349 | CharacterController-Unterstützung prüfen |
+| TODO-OPT#59 | Assets/Scripts/Map/MapStartupController.cs | CreateMinimalLevel(), Zeile 510 | Fallback-Level als Prefab realisieren |
+| TODO-OPT#60 | Assets/Scripts/PlayerController.cs | OnDestroy(), Zeile 528 | Von Events abmelden |
+| TODO-OPT#61 | Assets/Scripts/Generators/LevelGenerator.cs | ApplyMaterialsAndEffects(), Zeile 1461 | Steam-Emitter pooling umsetzen |
+| TODO-OPT#62 | Assets/Scripts/Map/MapGenerator.cs | AddSteampunkAtmosphere(), Zeile 1590 | Nebel-Parameter konfigurierbar machen |
+| TODO-OPT#63 | Assets/Scripts/UIController.cs | Zeile 983 | OnDestroy zum Deregistrieren der Events schreiben |
 


### PR DESCRIPTION
## Summary
- analyze scripts for maintainability
- add TODO hints for caching references, configurable parameters and cleanup
- list new TODOs in TODO_Index.md

## Testing
- `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6888fb66e428832487d3bd88ba5c801d