### PR TITLE
Fix errors from Editor.log

### DIFF
--- a/Assets/Editor/CleanRollABallMenu.cs
+++ b/Assets/Editor/CleanRollABallMenu.cs
@@ -392,7 +392,7 @@ namespace RollABall.Editor
             
             foreach (var renderer in renderers)
             {
-                if (// renderer // Fixed: UniversalSceneFixture has no gameObject.name.Contains("Ground"))
+                if (renderer.gameObject.name.Contains("Ground"))
                 {
                     Material steampunkMaterial = Resources.Load<Material>("SteamGroundMaterial");
                     if (steampunkMaterial)

--- a/Assets/Editor/OSMEditorExtension.cs
+++ b/Assets/Editor/OSMEditorExtension.cs
@@ -282,10 +282,10 @@ namespace RollABall.Editor
             }
             
             completer.CompleteOSMSceneSetup();
-            
-            if (// completer // Fixed: UniversalSceneFixture has no gameObject.name == "Temp_OSMSceneCompleter")
+
+            if (completer.gameObject.name == "Temp_OSMSceneCompleter")
             {
-                DestroyImmediate(// completer // Fixed: UniversalSceneFixture has no gameObject);
+                DestroyImmediate(completer.gameObject);
             }
             
             EditorUtility.DisplayDialog("Success", "OSM Scene setup completed!\nLevel_OSM is ready for use.", "OK");

--- a/Assets/Editor/ProjectCleanupAndFix.cs
+++ b/Assets/Editor/ProjectCleanupAndFix.cs
@@ -248,9 +248,9 @@ namespace RollABall.Editor
             CollectibleController[] collectibles = Object.FindObjectsByType<CollectibleController>(FindObjectsSortMode.None);
             foreach (CollectibleController collectible in collectibles)
             {
-                if (!// collectible // Fixed: UniversalSceneFixture has no gameObject.CompareTag("Collectible"))
+                if (!collectible.CompareTag("Collectible"))
                 {
-                    // collectible // Fixed: UniversalSceneFixture has no gameObject.tag = "Collectible";
+                    collectible.tag = "Collectible";
                     Debug.Log($"Fixed collectible tag in {sceneToFix.name}");
                 }
             }

--- a/Assets/Scripts/Editor/CleanRollABallMenuIntegration.cs
+++ b/Assets/Scripts/Editor/CleanRollABallMenuIntegration.cs
@@ -236,16 +236,16 @@ public class CleanRollABallMenuIntegration : EditorWindow
         {
             bool needsFix = false;
             
-            if (// collectible // Fixed: UniversalSceneFixture has no gameObject.tag != "Collectible")
+            if (collectible.tag != "Collectible")
             {
-                // collectible // Fixed: UniversalSceneFixture has no gameObject.tag = "Collectible";
+                collectible.tag = "Collectible";
                 needsFix = true;
             }
             
             Collider collider = collectible.GetComponent<Collider>();
             if (collider == null)
             {
-                SphereCollider sphereCollider = // collectible // Fixed: UniversalSceneFixture has no gameObject.AddComponent<SphereCollider>();
+                SphereCollider sphereCollider = collectible.gameObject.AddComponent<SphereCollider>();
                 sphereCollider.isTrigger = true;
                 needsFix = true;
             }
@@ -278,9 +278,9 @@ public class CleanRollABallMenuIntegration : EditorWindow
         
         tagManager.CompleteTagSetup();
         
-        if (// tagManager // Fixed: UniversalSceneFixture has no gameObject.name == "TempTagManager")
+        if (tagManager.gameObject.name == "TempTagManager")
         {
-            Object.DestroyImmediate(// tagManager // Fixed: UniversalSceneFixture has no gameObject);
+            Object.DestroyImmediate(tagManager.gameObject);
         }
         
         Debug.Log("[CleanMenu] Tags and layers setup completed");

--- a/Assets/Scripts/Editor/DiagnosticManager.cs
+++ b/Assets/Scripts/Editor/DiagnosticManager.cs
@@ -40,7 +40,7 @@ public class DiagnosticManager
             tool.enabled = false;
             EditorUtility.SetDirty(tool);
             disabledCount++;
-            Debug.Log($"[DiagnosticManager] CollectibleDiagnosticTool deaktiviert auf '{// tool // Fixed: UniversalSceneFixture has no gameObject.name}'");
+            Debug.Log($"[DiagnosticManager] CollectibleDiagnosticTool deaktiviert auf '{tool.gameObject.name}'");
         }
 
         // Deaktiviere LevelProgressionFixer falls vorhanden
@@ -52,7 +52,7 @@ public class DiagnosticManager
                 fixer.enabled = false;
                 EditorUtility.SetDirty(fixer);
                 disabledCount++;
-                Debug.Log($"[DiagnosticManager] LevelProgressionFixer deaktiviert auf '{// fixer // Fixed: UniversalSceneFixture has no gameObject.name}'");
+                Debug.Log($"[DiagnosticManager] LevelProgressionFixer deaktiviert auf '{fixer.gameObject.name}'");
             }
         }
 
@@ -64,7 +64,7 @@ public class DiagnosticManager
                 fixer.enabled = false;
                 EditorUtility.SetDirty(fixer);
                 disabledCount++;
-                Debug.Log($"[DiagnosticManager] MasterFixTool deaktiviert auf '{// fixer // Fixed: UniversalSceneFixture has no gameObject.name}'");
+                Debug.Log($"[DiagnosticManager] MasterFixTool deaktiviert auf '{fixer.gameObject.name}'");
             }
         }
 
@@ -133,7 +133,7 @@ public class DiagnosticManager
         foreach (var tool in diagnosticTools)
         {
             string state = tool.enabled ? "🟢 Aktiv" : "🔴 Deaktiviert";
-            status += $"   └─ {// tool // Fixed: UniversalSceneFixture has no gameObject.name}: {state}\n";
+            status += $"   └─ {tool.gameObject.name}: {state}\n";
         }
 
         // Prüfe andere Tools
@@ -149,7 +149,7 @@ public class DiagnosticManager
                     status += $"\n🛠️ Andere Fix-Tools:\n";
                 }
                 string state = component.enabled ? "🟢 Aktiv" : "🔴 Deaktiviert";
-                status += $"   └─ {typeName} auf {// component // Fixed: UniversalSceneFixture has no gameObject.name}: {state}\n";
+                status += $"   └─ {typeName} auf {component.gameObject.name}: {state}\n";
                 otherToolsCount++;
             }
         }

--- a/Assets/Scripts/Editor/UniversalSceneFixture.cs
+++ b/Assets/Scripts/Editor/UniversalSceneFixture.cs
@@ -141,7 +141,7 @@ public class UniversalSceneFixture : EditorWindow
             Canvas canvas = FindFirstObjectByType<Canvas>();
             if (canvas != null)
             {
-                uiController = // canvas // Fixed: UniversalSceneFixture has no gameObject.AddComponent<UIController>();
+                uiController = canvas.gameObject.AddComponent<UIController>();
                 LogFix("✅ Added UIController to Canvas");
             }
             else
@@ -245,7 +245,7 @@ public class UniversalSceneFixture : EditorWindow
             UnityEngine.UI.CanvasScaler scaler = canvas.GetComponent<UnityEngine.UI.CanvasScaler>();
             if (scaler == null)
             {
-                scaler = // canvas // Fixed: UniversalSceneFixture has no gameObject.AddComponent<UnityEngine.UI.CanvasScaler>();
+                scaler = canvas.gameObject.AddComponent<UnityEngine.UI.CanvasScaler>();
                 scaler.uiScaleMode = UnityEngine.UI.CanvasScaler.ScaleMode.ScaleWithScreenSize;
                 scaler.referenceResolution = new Vector2(1920, 1080);
                 LogFix("✅ Added CanvasScaler to Canvas");
@@ -265,9 +265,9 @@ public class UniversalSceneFixture : EditorWindow
             bool needsFix = false;
             
             // Ensure collectible has correct tag
-            if (// collectible // Fixed: UniversalSceneFixture has no gameObject.tag != "Collectible")
+            if (collectible.tag != "Collectible")
             {
-                // collectible // Fixed: UniversalSceneFixture has no gameObject.tag = "Collectible";
+                collectible.tag = "Collectible";
                 needsFix = true;
             }
             
@@ -275,7 +275,7 @@ public class UniversalSceneFixture : EditorWindow
             Collider collider = collectible.GetComponent<Collider>();
             if (collider == null)
             {
-                SphereCollider sphereCollider = // collectible // Fixed: UniversalSceneFixture has no gameObject.AddComponent<SphereCollider>();
+                SphereCollider sphereCollider = collectible.gameObject.AddComponent<SphereCollider>();
                 sphereCollider.isTrigger = true;
                 needsFix = true;
             }
@@ -328,7 +328,7 @@ public class UniversalSceneFixture : EditorWindow
             // Ensure GameManager is marked as DontDestroyOnLoad
             if (gameManager.transform.parent == null)
             {
-                DontDestroyOnLoad(// gameManager // Fixed: UniversalSceneFixture has no gameObject);
+                DontDestroyOnLoad(gameManager.gameObject);
                 LogFix("✅ Set GameManager as DontDestroyOnLoad");
             }
         }
@@ -460,13 +460,13 @@ public class UniversalSceneFixture : EditorWindow
         CollectibleController[] collectibles = FindObjectsByType<CollectibleController>(FindObjectsSortMode.None);
         bool collectiblesValid = true;
         
-        foreach (CollectibleController collectible in collectibles)
-        {
-            if (// collectible // Fixed: UniversalSceneFixture has no gameObject.tag != "Collectible")
+            foreach (CollectibleController collectible in collectibles)
             {
-                collectiblesValid = false;
-                break;
-            }
+                if (collectible.tag != "Collectible")
+                {
+                    collectiblesValid = false;
+                    break;
+                }
             
             Collider collider = collectible.GetComponent<Collider>();
             if (collider == null || !collider.isTrigger)


### PR DESCRIPTION
## Summary
- address invalid syntax in `CleanRollABallMenu`
- clean up OSM editor extension
- fix collectible tagging in project cleanup
- update clean menu integration
- repair diagnostic manager log messages
- resolve placeholders in UniversalSceneFixture

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688a1f6301248324a8ac761d8003b947