### PR TITLE
Fix UniversalSceneFixture compile errors

### DIFF
--- a/Assets/Editor/RollABallMenuIntegration.cs
+++ b/Assets/Editor/RollABallMenuIntegration.cs
@@ -376,14 +376,11 @@ public class RollABallMenuIntegration : EditorWindow
     
     private void RunUniversalSceneFixture()
     {
-        UniversalSceneFixture fixture = Object.FindFirstObjectByType<UniversalSceneFixture>();
-        if (!fixture)
-        {
-            GameObject fixtureGO = new GameObject("UniversalSceneFixture");
-            fixture = fixtureGO.AddComponent<UniversalSceneFixture>();
-        }
-        
+        // UniversalSceneFixture is an EditorWindow and cannot be added as a
+        // component. Create a temporary instance instead.
+        UniversalSceneFixture fixture = ScriptableObject.CreateInstance<UniversalSceneFixture>();
         fixture.FixCurrentScene();
+        Object.DestroyImmediate(fixture);
         EditorUtility.DisplayDialog("Universal Scene Fixture", "Scene fixture completed!", "OK");
     }
     
@@ -429,10 +426,11 @@ public class RollABallMenuIntegration : EditorWindow
     private void RemoveAllFixTools()
     {
         // Remove all fix tool components from the current scene
-        UniversalSceneFixture[] fixtures = Object.FindObjectsByType<UniversalSceneFixture>(FindObjectsSortMode.None);
-        foreach (var fixture in fixtures)
+        // Close any open UniversalSceneFixture windows
+        UniversalSceneFixture[] fixtures = Resources.FindObjectsOfTypeAll<UniversalSceneFixture>();
+        foreach (var window in fixtures)
         {
-            Object.DestroyImmediate(fixture.gameObject);
+            window.Close();
         }
         
         // Remove any other fix tools

--- a/Assets/Scripts/Editor/LevelGenerationInfo.cs
+++ b/Assets/Scripts/Editor/LevelGenerationInfo.cs
@@ -76,18 +76,10 @@ public class LevelGenerationInfo
             // Kurze Pause für Unity
             System.Threading.Thread.Sleep(500);
             
-            // Schritt 2: Validiere aktuelle Szene
-            UniversalSceneFixture fixture = Object.FindFirstObjectByType<UniversalSceneFixture>();
-            if (fixture == null)
-            {
-                GameObject fixtureGO = new GameObject("TempUniversalSceneFixture");
-                fixture = fixtureGO.AddComponent<UniversalSceneFixture>();
-            }
+            // Schritt 2: Validiere aktuelle Szene using a temporary EditorWindow
+            UniversalSceneFixture fixture = ScriptableObject.CreateInstance<UniversalSceneFixture>();
             fixture.FixCurrentScene();
-            if (fixture.gameObject.name == "TempUniversalSceneFixture")
-            {
-                Object.DestroyImmediate(fixture.gameObject);
-            }
+            Object.DestroyImmediate(fixture);
             
             // Schritt 3: Erfolgsmeldung
             EditorUtility.DisplayDialog(

--- a/Assets/Scripts/Editor/RollABallControlPanel.cs
+++ b/Assets/Scripts/Editor/RollABallControlPanel.cs
@@ -604,11 +604,10 @@ public class RollABallControlPanel : EditorWindow
             uiControllerGO.AddComponent<UIController>();
         }
         
-        // Add UniversalSceneFixture
-        if (!FindFirstObjectByType<UniversalSceneFixture>())
+        // Launch UniversalSceneFixture window for scene validation
+        if (Resources.FindObjectsOfTypeAll<UniversalSceneFixture>().Length == 0)
         {
-            GameObject fixtureGO = new GameObject("UniversalSceneFixture");
-            fixtureGO.AddComponent<UniversalSceneFixture>();
+            UniversalSceneFixture.ShowWindow();
         }
         
         Debug.Log("Added essential scene components");


### PR DESCRIPTION
## Summary
- fix RunUniversalSceneFixture to instantiate EditorWindow instead of using AddComponent
- close UniversalSceneFixture windows when removing tools
- update LevelGenerationInfo and RollABallControlPanel to avoid AddComponent

## Testing
- `grep -n "error" Logs/Editor.log | head` *(fails: old log shows compile errors, new code not compiled)*

------
https://chatgpt.com/codex/tasks/task_e_688a268347408324be67894ccca9bd27