### PR TITLE
Fix RemoveFixTools method

### DIFF
--- a/Assets/Editor/RollABallMenuIntegration.cs
+++ b/Assets/Editor/RollABallMenuIntegration.cs
@@ -531,10 +531,11 @@ public class RollABallMenuItems
     public static void RemoveFixTools()
     {
         // Remove fix tools from current scene
-        UniversalSceneFixture[] fixtures = Object.FindObjectsByType<UniversalSceneFixture>(FindObjectsSortMode.None);
+        // Close any open UniversalSceneFixture editor windows
+        UniversalSceneFixture[] fixtures = Resources.FindObjectsOfTypeAll<UniversalSceneFixture>();
         foreach (var fixture in fixtures)
         {
-            Object.DestroyImmediate(fixture.gameObject);
+            fixture.Close();
         }
         Debug.Log("Fix tools removed from current scene.");
     }


### PR DESCRIPTION
## Summary
- close UniversalSceneFixture windows instead of destroying nonexistent GameObjects

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a27f06ee483248ff6ca87b75846bb