### PR TITLE
Fix collectible rotation on local axis

### DIFF
--- a/Assets/Scripts/CollectibleController.cs
+++ b/Assets/Scripts/CollectibleController.cs
@@ -158,8 +158,9 @@ public class CollectibleController : MonoBehaviour
     {
         if (collectibleData.rotateObject)
         {
-            // Rotate around local Y-axis to ensure independent spinning
-            transform.Rotate(Vector3.up, collectibleData.rotationSpeed * Time.deltaTime, Space.Self);
+            // Rotate around the object's local Y-axis so each collectible spins independently
+            Quaternion rotation = Quaternion.Euler(0f, collectibleData.rotationSpeed * Time.deltaTime, 0f);
+            transform.localRotation *= rotation;
         }
     }
 


### PR DESCRIPTION
## Summary
- ensure collectibles rotate around their own local Y-axis

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a2c164c6c83248147036a86a080a6