### PR TITLE
Fix collectible rotation axis

### DIFF
--- a/Assets/Scripts/CollectibleController.cs
+++ b/Assets/Scripts/CollectibleController.cs
@@ -158,10 +158,9 @@ public class CollectibleController : MonoBehaviour
     {
         if (collectibleData.rotateObject)
         {
-
-            // Rotate around the object's local Y-axis so each collectible spins independently
-            Quaternion rotation = Quaternion.Euler(0f, collectibleData.rotationSpeed * Time.deltaTime, 0f);
-            transform.localRotation *= rotation;
+            // Rotate around the object's local Y-axis
+            // This keeps each collectible spinning in place regardless of parent rotation
+            transform.Rotate(Vector3.up, collectibleData.rotationSpeed * Time.deltaTime, Space.Self);
         }
     }
 


### PR DESCRIPTION
## Summary
- ensure collectibles rotate around their own Y-axis

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688a308493588324b862cb522781e0b5