### PR TITLE
Fix NRE when applying slippery physics

### DIFF
--- a/Assets/Scripts/Generators/LevelEffectManager.cs
+++ b/Assets/Scripts/Generators/LevelEffectManager.cs
@@ -234,7 +234,9 @@ namespace RollABall.Generators
         /// </summary>
         public void ApplySlipperyPhysics(GameObject obj)
         {
-            if (!activeProfile.EnableSlipperyTiles || activeProfile.SlipperyMaterial == null) return;
+            if (obj == null || activeProfile == null ||
+                !activeProfile.EnableSlipperyTiles || activeProfile.SlipperyMaterial == null)
+                return;
 
             if (random.NextDouble() < activeProfile.SlipperyTileChance)
             {


### PR DESCRIPTION
## Summary
- prevent null reference if LevelEffectManager isn't initialized

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_688a4e1d53b08324a9aa4aacb8aaf469