### PR TITLE
Implement TODO items for Achievement events and bounce constants

### DIFF
--- a/Assets/Scripts/AchievementSystem.cs
+++ b/Assets/Scripts/AchievementSystem.cs
@@ -107,6 +107,7 @@ public class AchievementSystem : MonoBehaviour
     private Dictionary<string, Achievement> achievementLookup;
     private Queue<Achievement> pendingNotifications;
     private bool isShowingNotification = false;
+    private PlayerController cachedPlayer;
     
     // Events
     public System.Action<Achievement> OnAchievementUnlocked;
@@ -292,11 +293,32 @@ public class AchievementSystem : MonoBehaviour
         }
         
         // Subscribe to player events
-        PlayerController player = FindFirstObjectByType<PlayerController>(); // TODO: Cache reference to avoid repeated searches
-        if (player)
+        cachedPlayer = FindFirstObjectByType<PlayerController>();
+        if (cachedPlayer)
         {
-            player.OnGroundedChanged += OnPlayerGrounded;
-            player.OnFlyingChanged += OnPlayerFlying;
+            cachedPlayer.OnGroundedChanged += OnPlayerGrounded;
+            cachedPlayer.OnFlyingChanged += OnPlayerFlying;
+        }
+    }
+
+    private void UnsubscribeFromGameEvents()
+    {
+        if (GameManager.Instance)
+        {
+            GameManager.Instance.OnGameStateChanged -= OnGameStateChanged;
+            GameManager.Instance.OnStatisticsUpdated -= OnStatisticsUpdated;
+        }
+
+        if (LevelManager.Instance)
+        {
+            LevelManager.Instance.OnLevelCompleted -= OnLevelCompleted;
+            LevelManager.Instance.OnCollectibleCountChanged -= OnCollectibleCountChanged;
+        }
+
+        if (cachedPlayer)
+        {
+            cachedPlayer.OnGroundedChanged -= OnPlayerGrounded;
+            cachedPlayer.OnFlyingChanged -= OnPlayerFlying;
         }
     }
     
@@ -717,6 +739,6 @@ public class AchievementSystem : MonoBehaviour
     {
         // Save progress before destruction
         SaveAchievementProgress();
-        // TODO: Unsubscribe from game events to prevent memory leaks
+        UnsubscribeFromGameEvents();
     }
 }

--- a/Assets/Scripts/Environment/MovingPlatform.cs
+++ b/Assets/Scripts/Environment/MovingPlatform.cs
@@ -15,6 +15,9 @@ namespace RollABall.Environment
         private const float BounceStage2 = 2f / BounceDiv;
         private const float BounceStage3 = 2.5f / BounceDiv;
         private const float BounceStage4 = 2.625f / BounceDiv;
+        private const float BounceReturn1 = 0.75f;
+        private const float BounceReturn2 = 0.9375f;
+        private const float BounceReturn3 = 0.984375f;
 
         [Header("Bewegungseinstellungen")]
         [SerializeField] private Vector3 startPosition;
@@ -251,15 +254,15 @@ namespace RollABall.Environment
             }
             else if (t < BounceStage2)
             {
-                return BounceFactor * (t -= (1.5f / BounceDiv)) * t + 0.75f;
+                return BounceFactor * (t -= (1.5f / BounceDiv)) * t + BounceReturn1;
             }
             else if (t < BounceStage3)
             {
-                return BounceFactor * (t -= (2.25f / BounceDiv)) * t + 0.9375f;
+                return BounceFactor * (t -= (2.25f / BounceDiv)) * t + BounceReturn2;
             }
             else
             {
-                return BounceFactor * (t -= (BounceStage4)) * t + 0.984375f;
+                return BounceFactor * (t -= (BounceStage4)) * t + BounceReturn3;
             }
         }
         

--- a/TODO_Index.md
+++ b/TODO_Index.md
@@ -45,8 +45,8 @@
 | TODO-OPT#41 | Assets/Scripts/Map/MapStartupController.cs | LoadMapFromAddress(), Zeile 244 | Adressauflösung asynchron ausführen |
 | TODO-OPT#42 | Assets/Scripts/ProgressionManager.cs | CreateDefaultLevels(), Zeile 203 | Leveldaten extern speichern |
 | TODO-OPT#43 | Assets/Scripts/AchievementSystem.cs | CreateDefaultAchievements(), Zeile 186 | Achievements aus externer Konfiguration laden |
-| TODO-OPT#44 | Assets/Scripts/AchievementSystem.cs | SubscribeToGameEvents(), Zeile 295 | PlayerController-Referenz cachen |
-| TODO-OPT#45 | Assets/Scripts/AchievementSystem.cs | OnDestroy(), Zeile 720 | Von GameEvents abmelden |
+| TODO-OPT#44 | Assets/Scripts/AchievementSystem.cs | SubscribeToGameEvents(), Zeile 295 | PlayerController-Referenz cachen | **erledigt** |
+| TODO-OPT#45 | Assets/Scripts/AchievementSystem.cs | OnDestroy(), Zeile 720 | Von GameEvents abmelden | **erledigt** |
 | TODO-OPT#46 | Assets/Scripts/GameManager.cs | pauseKey, Zeile 32 | Pause-Taste im Einstellungsmenü konfigurierbar machen |
 | TODO-OPT#47 | Assets/Scripts/GameManager.cs | TrackStatistics(), Zeile 406 | Update-Intervall einstellbar machen |
 | TODO-OPT#48 | Assets/Scripts/Map/MapGenerator.cs | GenerateCollectiblePositions(), Zeile 708 | Offsetbereich als Felder exposen |
@@ -58,7 +58,7 @@
 | TODO-OPT#54 | Assets/Scripts/Map/MapGeneratorBatched.cs | InitializeBatchingCollections(), Zeile 114 | String-Keys durch Enum ersetzen |
 | TODO-OPT#55 | Assets/Scripts/Environment/SteampunkGateController.cs | InitializeGate(), Zeile 122 | Manager-Referenzen per Inspector setzen |
 | TODO-OPT#56 | Assets/Scripts/Environment/SteampunkGateController.cs | Zeile 665 | OnDestroy zur Coroutine-Aufräumung einführen |
-| TODO-OPT#57 | Assets/Scripts/Environment/MovingPlatform.cs | BounceEaseOut(), Zeile 241 | Magic Numbers durch Konstanten ersetzen |
+| TODO-OPT#57 | Assets/Scripts/Environment/MovingPlatform.cs | BounceEaseOut(), Zeile 241 | Magic Numbers durch Konstanten ersetzen | **erledigt** |
 | TODO-OPT#58 | Assets/Scripts/Environment/MovingPlatform.cs | OnTriggerEnter(), Zeile 349 | CharacterController-Unterstützung prüfen |
 | TODO-OPT#59 | Assets/Scripts/Map/MapStartupController.cs | CreateMinimalLevel(), Zeile 510 | Fallback-Level als Prefab realisieren |
 | TODO-OPT#60 | Assets/Scripts/PlayerController.cs | OnDestroy(), Zeile 528 | Von Events abmelden | **erledigt** |
@@ -71,5 +71,5 @@
 | TODO-OPT#67 | Assets/Scripts/VFX/SteamEmitter.cs | RandomizeSettings(), Zeile 249 | Zufallsbereiche per Inspector konfigurierbar machen |
 | TODO-OPT#68 | Assets/Scripts/SceneTypeDetector.cs | Zeile 18 | Szenenlisten aus Konfiguration laden |
 | TODO-OPT#69 | Assets/Scripts/CollectibleDiagnosticTool.cs | FindAllCollectibles(), Zeile 94 | Suchergebnisse cachen, um Allokationen zu vermeiden |
-| TODO-OPT#70 | Assets/Scripts/Map/MapStartupController.cs | leipzigCoords, Zeile 53 | Fallback-Koordinaten im Inspector einstellbar machen |
+| TODO-OPT#70 | Assets/Scripts/Map/MapStartupController.cs | leipzigCoords, Zeile 53 | Fallback-Koordinaten im Inspector einstellbar machen | **erledigt** |
 


### PR DESCRIPTION
## Summary
- cache `PlayerController` in `AchievementSystem` and clean up event subscriptions
- remove magic numbers in `MovingPlatform` bounce easing logic
- mark completed items in `TODO_Index.md`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a6136e1208324989e34cbe1567a26