### PR TITLE
Add maintainability TODOs across scripts

### DIFF
--- a/Assets/Scripts/Generators/LevelGenerator.cs
+++ b/Assets/Scripts/Generators/LevelGenerator.cs
@@ -393,6 +393,7 @@ public class LevelGenerator : MonoBehaviour
         try
         {
             var methodInfo = activeProfile.GetType().GetMethod("GetAdaptiveGenerationMode");
+            // TODO: Replace reflection with an interface for adaptive mode selection
             if (methodInfo != null)
             {
                 usedGenerationMode = (LevelGenerationMode)methodInfo.Invoke(activeProfile, new object[] { seed });

--- a/Assets/Scripts/Generators/LevelTerrainGenerator.cs
+++ b/Assets/Scripts/Generators/LevelTerrainGenerator.cs
@@ -159,6 +159,7 @@ namespace RollABall.Generators
         try
         {
             var methodInfo = profile.GetType().GetMethod("GetAdaptiveGenerationMode");
+            // TODO: Refactor to interface-based lookup instead of reflection
             if (methodInfo != null)
             {
                 return (LevelGenerationMode)methodInfo.Invoke(profile, new object[] { random.Next() });

--- a/Assets/Scripts/Input/InputManager.cs
+++ b/Assets/Scripts/Input/InputManager.cs
@@ -18,6 +18,7 @@ namespace RollABall.InputSystem
         [SerializeField] private KeyCode flyKey = KeyCode.F;
         [SerializeField] private KeyCode sprintKey = KeyCode.LeftShift;
         [SerializeField] private KeyCode slideKey = KeyCode.LeftControl;
+        // TODO: Allow runtime key rebinding via settings menu
 
         private void Awake()
         {

--- a/Assets/Scripts/Map/BatchingPerformanceTest.cs
+++ b/Assets/Scripts/Map/BatchingPerformanceTest.cs
@@ -168,9 +168,10 @@ namespace RollABall.Map
             List<float> frameTimes = new List<float>();
             int initialGameObjects = 0;
             int finalGameObjects = 0;
-            
+
             // Take baseline measurements
             initialGameObjects = FindObjectsByType<GameObject>(FindObjectsSortMode.None).Length;
+            // TODO: Cache object list to avoid allocations during testing
             
             // Generate map and measure time
             float startTime = Time.realtimeSinceStartup;

--- a/Assets/Scripts/Map/MapGenerator.cs
+++ b/Assets/Scripts/Map/MapGenerator.cs
@@ -1489,7 +1489,8 @@ namespace RollABall.Map
                     0.5f,
                     Random.Range(-buildingSize.z * 0.3f, buildingSize.z * 0.3f)
                 );
-                
+                // TODO: Expose chimney offset factors via inspector fields
+
                 GameObject steamEmitter = Instantiate(chimneySmokeParticles, chimneyPos, Quaternion.identity);
                 steamEmitter.transform.SetParent(buildingObject.transform);
                 steamEmitter.name = "ChimneySteam";
@@ -1506,6 +1507,7 @@ namespace RollABall.Map
                         Random.Range(-0.2f, 0.5f),
                         Random.Range(-buildingSize.z * 0.4f, buildingSize.z * 0.4f)
                     );
+                    // TODO: Make gear decoration ranges configurable in LevelProfile
                     
                     GameObject gear = Instantiate(gearPrefab, gearPos, 
                         Quaternion.Euler(Random.Range(0, 360), Random.Range(0, 360), Random.Range(0, 360)));

--- a/CodeReview_TODOs.md
+++ b/CodeReview_TODOs.md
@@ -18,3 +18,9 @@ The following TODO comments were added during code review to highlight potential
 | Assets/Scripts/SceneTypeDetector.cs | 18 | Read scene lists from config instead of hardcoding |
 | Assets/Scripts/CollectibleDiagnosticTool.cs | 94 | Cache results to avoid allocations |
 | Assets/Scripts/Map/MapStartupController.cs | 53 | Allow editing fallback coordinates in inspector |
+| Assets/Scripts/Input/InputManager.cs | 21 | Allow runtime key rebinding via settings menu |
+| Assets/Scripts/Map/MapGenerator.cs | 1492 | Expose chimney offset factors via inspector fields |
+| Assets/Scripts/Map/MapGenerator.cs | 1510 | Make gear decoration ranges configurable in LevelProfile |
+| Assets/Scripts/Generators/LevelGenerator.cs | 396 | Replace reflection with an interface for adaptive mode selection |
+| Assets/Scripts/Generators/LevelTerrainGenerator.cs | 162 | Refactor to interface-based lookup instead of reflection |
+| Assets/Scripts/Map/BatchingPerformanceTest.cs | 174 | Cache object list to avoid allocations during testing |


### PR DESCRIPTION
## Summary
- add runtime key rebinding TODO in `InputManager`
- note configurable offsets for map decorations in `MapGenerator`
- suggest interface-based generation mode selection in `LevelGenerator` and `LevelTerrainGenerator`
- warn about allocations in `BatchingPerformanceTest`
- document all new TODOs in `CodeReview_TODOs.md`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a64b339448324a0179e506d9a1469