### PR TITLE
Implement configurable input and async saving

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -52,6 +52,18 @@ public class GameManager : MonoBehaviour
     [SerializeField] private GameStats gameStats;
     [SerializeField] private float statisticsUpdateInterval = 0.1f;
 
+    /// <summary>
+    /// Set update interval for statistics tracking at runtime.
+    /// </summary>
+    public void SetStatisticsUpdateInterval(float interval)
+    {
+        statisticsUpdateInterval = Mathf.Max(0.02f, interval);
+        if (currentState == GameState.Playing && statisticsCoroutine != null)
+        {
+            StartStatisticsTracking();
+        }
+    }
+
     [Header("Checkpoints")]
     [SerializeField] private Transform[] checkpoints;
     [SerializeField] private float checkpointRadius = 2f;
@@ -133,12 +145,9 @@ public class GameManager : MonoBehaviour
         }
         if (InputManager.Instance != null)
         {
-            // migrate legacy key bindings if they were set in the scene
-            var mgr = InputManager.Instance;
-            var pauseField = pauseKey;
-            var restartField = restartKey;
-            typeof(InputManager).GetField("pauseKey", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.SetValue(mgr, pauseField);
-            typeof(InputManager).GetField("restartKey", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.SetValue(mgr, restartField);
+            // apply configured bindings
+            InputManager.Instance.SetPauseKey(pauseKey);
+            InputManager.Instance.SetRestartKey(restartKey);
         }
         
         // CLAUDE: FIXED - Use cached references instead of Find calls

--- a/Assets/Scripts/Input/InputManager.cs
+++ b/Assets/Scripts/Input/InputManager.cs
@@ -12,6 +12,9 @@ namespace RollABall.InputSystem
         public static InputManager Instance { get; private set; }
 
         [Header("Key Bindings")]
+        private const string PauseKeyPref = "PauseKey";
+        private const string RestartKeyPref = "RestartKey";
+
         [SerializeField] private KeyCode pauseKey = KeyCode.Escape;
         [SerializeField] private KeyCode restartKey = KeyCode.R;
         [SerializeField] private KeyCode jumpKey = KeyCode.Space;
@@ -29,6 +32,35 @@ namespace RollABall.InputSystem
             }
             Instance = this;
             DontDestroyOnLoad(gameObject);
+
+            LoadKeyBindings();
+        }
+
+        private void LoadKeyBindings()
+        {
+            if (PlayerPrefs.HasKey(PauseKeyPref))
+            {
+                if (System.Enum.TryParse(PlayerPrefs.GetString(PauseKeyPref), out KeyCode key))
+                    pauseKey = key;
+            }
+
+            if (PlayerPrefs.HasKey(RestartKeyPref))
+            {
+                if (System.Enum.TryParse(PlayerPrefs.GetString(RestartKeyPref), out KeyCode key))
+                    restartKey = key;
+            }
+        }
+
+        public void SetPauseKey(KeyCode key)
+        {
+            pauseKey = key;
+            PlayerPrefs.SetString(PauseKeyPref, key.ToString());
+        }
+
+        public void SetRestartKey(KeyCode key)
+        {
+            restartKey = key;
+            PlayerPrefs.SetString(RestartKeyPref, key.ToString());
         }
 
         /// <summary>

--- a/Assets/Scripts/SaveSystem.cs
+++ b/Assets/Scripts/SaveSystem.cs
@@ -2,6 +2,7 @@ using UnityEngine;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
+using System.Threading.Tasks;
 
 /// <summary>
 /// Advanced save system for Roll-a-Ball progress, settings, and achievements
@@ -181,21 +182,21 @@ public class SaveSystem : MonoBehaviour
     /// <summary>
     /// Save current game state to the active slot
     /// </summary>
-    public void SaveCurrentGame()
+    public async void SaveCurrentGame()
     {
         if (currentSave == null)
         {
             LogSave("No save data to save!", true);
             return;
         }
-        
-        SaveToSlot(activeSaveSlot);
+
+        await SaveToSlot(activeSaveSlot);
     }
     
     /// <summary>
     /// Save current game state to a specific slot
     /// </summary>
-    public void SaveToSlot(int slot)
+    public async Task SaveToSlot(int slot)
     {
         if (slot < 0 || slot >= maxSaveSlots)
         {
@@ -220,11 +221,11 @@ public class SaveSystem : MonoBehaviour
             // Save the data
             if (encryptSaveFiles)
             {
-                SaveEncrypted(filePath, currentSave);
+                await SaveEncrypted(filePath, currentSave);
             }
             else
             {
-                SaveUnencrypted(filePath, currentSave);
+                await SaveUnencrypted(filePath, currentSave);
             }
             
             isDirty = false;
@@ -354,11 +355,10 @@ public class SaveSystem : MonoBehaviour
     
     #region File Operations
     
-    private void SaveUnencrypted(string filePath, SaveData data)
+    private async System.Threading.Tasks.Task SaveUnencrypted(string filePath, SaveData data)
     {
         string json = JsonUtility.ToJson(data, true);
-        File.WriteAllText(filePath, json);
-        // TODO: Use async file IO to prevent frame spikes on save
+        await File.WriteAllTextAsync(filePath, json);
     }
     
     private SaveData LoadUnencrypted(string filePath)
@@ -367,12 +367,11 @@ public class SaveSystem : MonoBehaviour
         return JsonUtility.FromJson<SaveData>(json);
     }
     
-    private void SaveEncrypted(string filePath, SaveData data)
+    private async System.Threading.Tasks.Task SaveEncrypted(string filePath, SaveData data)
     {
         string json = JsonUtility.ToJson(data, true);
         string encrypted = EncryptString(json, encryptionKey);
-        File.WriteAllText(filePath, encrypted);
-        // TODO: Use async file IO to prevent frame spikes on save
+        await File.WriteAllTextAsync(filePath, encrypted);
     }
     
     private SaveData LoadEncrypted(string filePath)

--- a/TODO_Index.md
+++ b/TODO_Index.md
@@ -34,7 +34,7 @@
 | TODO-OPT#30 | Assets/Scripts/OSMGoalZoneTrigger.cs | SetupGoalZone(), Zeile 40 | Fallback bei fehlendem LevelManager einbauen | **erledigt** |
 | TODO-OPT#31 | Assets/Scripts/Map/MapStartupController.cs | GetCoordsFromAddress(), Zeile 403 | Geocoding-Service integrieren |
 | TODO-OPT#32 | Assets/Scripts/Map/MapGeneratorBatched.cs | CreateSeparateColliders(), Zeile 548 | Collider-Pooling zur GC-Reduktion |
-| TODO-OPT#33 | Assets/Scripts/SaveSystem.cs | SaveEncrypted()/SaveUnencrypted(), Zeile 360/348 | Async File IO verwenden |
+| TODO-OPT#33 | Assets/Scripts/SaveSystem.cs | SaveEncrypted()/SaveUnencrypted(), Zeile 360/348 | Async File IO verwenden | **erledigt** |
 | TODO-OPT#34 | Assets/Scripts/AchievementSystem.cs | OnLevelCompleted(), Zeile 332 | Levelnamen nicht per String vergleichen | **erledigt** |
 | TODO-OPT#35 | Assets/Scripts/AchievementSystem.cs | DisplayNotificationCoroutine(), Zeile 558 | Notification-Objekte poolen | **erledigt** |
 | TODO-OPT#36 | Assets/Scripts/AudioManager.cs | GetAvailableSource(), Zeile 359 | Pool dynamisch vergrößern | **erledigt** |
@@ -47,8 +47,8 @@
 | TODO-OPT#43 | Assets/Scripts/AchievementSystem.cs | CreateDefaultAchievements(), Zeile 186 | Achievements aus externer Konfiguration laden |
 | TODO-OPT#44 | Assets/Scripts/AchievementSystem.cs | SubscribeToGameEvents(), Zeile 295 | PlayerController-Referenz cachen | **erledigt** |
 | TODO-OPT#45 | Assets/Scripts/AchievementSystem.cs | OnDestroy(), Zeile 720 | Von GameEvents abmelden | **erledigt** |
-| TODO-OPT#46 | Assets/Scripts/GameManager.cs | pauseKey, Zeile 32 | Pause-Taste im Einstellungsmenü konfigurierbar machen |
-| TODO-OPT#47 | Assets/Scripts/GameManager.cs | TrackStatistics(), Zeile 406 | Update-Intervall einstellbar machen |
+| TODO-OPT#46 | Assets/Scripts/GameManager.cs | pauseKey, Zeile 32 | Pause-Taste im Einstellungsmenü konfigurierbar machen | **erledigt** |
+| TODO-OPT#47 | Assets/Scripts/GameManager.cs | TrackStatistics(), Zeile 406 | Update-Intervall einstellbar machen | **erledigt** |
 | TODO-OPT#48 | Assets/Scripts/Map/MapGenerator.cs | GenerateCollectiblePositions(), Zeile 708 | Offsetbereich als Felder exposen | **erledigt** |
 | TODO-OPT#49 | Assets/Scripts/Map/MapGenerator.cs | FindOptimalGoalPosition(), Zeile 736 | Pfadfindung zur Zielplatzierung nutzen |
 | TODO-OPT#50 | Assets/Scripts/Map/MapStartupController.cs | endlessModeAddresses, Zeile 41 | Adressliste extern speichern | **erledigt** |

--- a/TODO_Review.md
+++ b/TODO_Review.md
@@ -1,4 +1,4 @@
 # TODO Review
 The following tasks from `TODO_Index.md` remain open due to missing files or larger refactors:
 - **TODO-OPT#14 - TODO-OPT#15**: AutoSceneRepair.cs and AutoSceneSetup.cs are missing from the repository, so the proposed helper methods cannot be implemented.
-- **TODO-OPT#18 - TODO-OPT#33**: Corresponding files or broader architecture changes are absent or complex. These items remain open for future work.
+- **TODO-OPT#18 - TODO-OPT#32**: Corresponding files or broader architecture changes are absent or complex. These items remain open for future work.


### PR DESCRIPTION
## Summary
- enable persistent key rebinding in `InputManager`
- use new input methods from `GameManager`
- allow runtime change of statistics update interval
- switch `SaveSystem` to async file IO
- mark completed TODOs in docs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a7332e55083249b72d3c32046a781