### PR TITLE
Fix area material assignment

### DIFF
--- a/Assets/Scripts/Map/MapGeneratorBatched.cs
+++ b/Assets/Scripts/Map/MapGeneratorBatched.cs
@@ -880,7 +880,8 @@ namespace RollABall.Map
                 areaObject.name = $"Area_{area.areaType}_{area.id}";
                 
                 MeshRenderer renderer = areaObject.GetComponent<MeshRenderer>();
-                renderer.material = GetAreaMaterial(area.areaType);
+                AreaCategory materialKey = GetAreaMaterialKey(area.areaType);
+                renderer.material = GetAreaMaterial(materialKey);
                 
                 if (enableStaticBatching)
                 {


### PR DESCRIPTION
## Summary
- fix incorrect parameter type when retrieving area materials

## Testing
- `dotnet build` *(fails: no project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_688a7b5e533483249f271c22c5878e73