### PR TITLE
Fix collectibles rotation

### DIFF
--- a/Assets/Scripts/CollectibleController.cs
+++ b/Assets/Scripts/CollectibleController.cs
@@ -79,7 +79,7 @@ public class CollectibleController : MonoBehaviour
     {
         if (!collectibleData.isCollected)
         {
-            HandleRotation();
+            RotateLocally();
             HandlePulseEffect();
         }
     }
@@ -158,14 +158,13 @@ public class CollectibleController : MonoBehaviour
         }
     }
 
-    private void HandleRotation()
+    private void RotateLocally()
     {
-        if (collectibleData.rotateObject)
-        {
-            // Rotate around the object's local Y-axis
-            // This keeps each collectible spinning in place regardless of parent rotation
-            transform.Rotate(Vector3.up, collectibleData.rotationSpeed * Time.deltaTime, Space.Self);
-        }
+        if (!collectibleData.rotateObject) return;
+
+        // Rotate around this object's local Y-axis
+        float angle = collectibleData.rotationSpeed * Time.deltaTime;
+        transform.localRotation *= Quaternion.Euler(0f, angle, 0f);
     }
 
     private void HandlePulseEffect()

--- a/wiki/docs/development/fix_collectible_rotation.md
+++ b/wiki/docs/development/fix_collectible_rotation.md
@@ -1,0 +1,4 @@
+# Fix Collectible Rotation
+
+The global rotation issue was traced back to `CollectibleController.HandleRotation`. The function has been removed and replaced with `RotateLocally`, which applies rotation using `transform.localRotation` to ensure every collectible spins around its own pivot. Update loops now call `RotateLocally()`.
+


### PR DESCRIPTION
## Summary
- fix collectible rotation by replacing HandleRotation with RotateLocally
- document the change

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a8ca50ec083249c571412260c84b4