### PR TITLE
Implement several TODO optimizations

### DIFF
--- a/Assets/Scripts/Map/BatchingPerformanceTest.cs
+++ b/Assets/Scripts/Map/BatchingPerformanceTest.cs
@@ -32,6 +32,8 @@ namespace RollABall.Map
         private MapGenerator originalGenerator;
         private MapGeneratorBatched batchedGenerator;
         private PerformanceMonitor performanceMonitor;
+        // Cached list to avoid allocations when counting objects
+        private readonly List<GameObject> objectCache = new();
         
         private void Start()
         {
@@ -170,8 +172,9 @@ namespace RollABall.Map
             int finalGameObjects = 0;
 
             // Take baseline measurements
-            initialGameObjects = FindObjectsByType<GameObject>(FindObjectsSortMode.None).Length;
-            // TODO: Cache object list to avoid allocations during testing
+            objectCache.Clear();
+            objectCache.AddRange(FindObjectsByType<GameObject>(FindObjectsSortMode.None));
+            initialGameObjects = objectCache.Count;
             
             // Generate map and measure time
             float startTime = Time.realtimeSinceStartup;
@@ -195,7 +198,9 @@ namespace RollABall.Map
             totalTime = endTime - startTime;
             
             // Take post-generation measurements
-            finalGameObjects = FindObjectsByType<GameObject>(FindObjectsSortMode.None).Length;
+            objectCache.Clear();
+            objectCache.AddRange(FindObjectsByType<GameObject>(FindObjectsSortMode.None));
+            finalGameObjects = objectCache.Count;
             
             // Warmup period
             yield return new WaitForSeconds(warmupTime);

--- a/Assets/Scripts/Map/PerformanceMonitor.cs
+++ b/Assets/Scripts/Map/PerformanceMonitor.cs
@@ -37,6 +37,10 @@ namespace RollABall.Map
         private int batchedObjects;
         private int separateColliders;
         private float lastGenerationTime;
+
+        // Cache for color textures created for GUI backgrounds
+        private readonly System.Collections.Generic.Dictionary<Color, Texture2D> textureCache
+            = new();
         
         // Display state
         private bool isVisible = true;
@@ -113,14 +117,19 @@ namespace RollABall.Map
             
             backgroundStyle = new GUIStyle(GUI.skin.box);
             backgroundStyle.normal.background = CreateColorTexture(backgroundColor);
-            // TODO: Cache created textures if display colors change frequently
         }
-        
+
         private Texture2D CreateColorTexture(Color color)
         {
+            if (textureCache.TryGetValue(color, out var cached))
+            {
+                return cached;
+            }
+
             Texture2D texture = new Texture2D(1, 1);
             texture.SetPixel(0, 0, color);
             texture.Apply();
+            textureCache[color] = texture;
             return texture;
         }
         

--- a/Assets/Scripts/Utility/PrefabPooler.cs
+++ b/Assets/Scripts/Utility/PrefabPooler.cs
@@ -13,15 +13,17 @@ namespace RollABall.Utility
         {
             public readonly GameObject prefab;
             public readonly Queue<GameObject> objects = new Queue<GameObject>();
+            public int maxSize;
 
-            public Pool(GameObject prefab)
+            public Pool(GameObject prefab, int maxSize)
             {
                 this.prefab = prefab;
+                this.maxSize = maxSize;
             }
         }
 
         private static readonly Dictionary<GameObject, Pool> pools = new Dictionary<GameObject, Pool>();
-        // TODO: Add maximum pool size to prevent uncontrolled growth
+        private const int DefaultMaxPoolSize = 20;
 
         /// <summary>
         /// Get a pooled instance of the given prefab.
@@ -29,10 +31,10 @@ namespace RollABall.Utility
         public static GameObject Get(GameObject prefab, Vector3 position, Quaternion rotation, Transform parent = null)
         {
             if (!prefab) return null;
-            
+
             if (!pools.TryGetValue(prefab, out Pool pool))
             {
-                pool = new Pool(prefab);
+                pool = new Pool(prefab, DefaultMaxPoolSize);
                 pools[prefab] = pool;
             }
 
@@ -63,11 +65,35 @@ namespace RollABall.Utility
             {
                 obj.SetActive(false);
                 obj.transform.SetParent(null);
-                pool.objects.Enqueue(obj);
+                if (pool.objects.Count < pool.maxSize)
+                {
+                    pool.objects.Enqueue(obj);
+                }
+                else
+                {
+                    Object.Destroy(obj);
+                }
             }
             else
             {
                 Object.Destroy(obj);
+            }
+        }
+
+        /// <summary>
+        /// Set a custom maximum pool size for the specified prefab.
+        /// </summary>
+        public static void SetMaxPoolSize(GameObject prefab, int size)
+        {
+            if (!prefab || size < 0) return;
+            if (!pools.TryGetValue(prefab, out Pool pool))
+            {
+                pool = new Pool(prefab, size);
+                pools[prefab] = pool;
+            }
+            else
+            {
+                pool.maxSize = size;
             }
         }
 


### PR DESCRIPTION
## Summary
- cache object list in `BatchingPerformanceTest` to reduce allocations
- cache GUI color textures in `PerformanceMonitor`
- add configurable maximum size to `PrefabPooler` pools

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_688afcd9fa54832490d143f4ead78118