### PR TITLE
Fix missing MapPathfindingUtility by correcting meta GUID

### DIFF
--- a/Assets/Scripts/Map/MapPathfindingUtility.cs.meta
+++ b/Assets/Scripts/Map/MapPathfindingUtility.cs.meta
@@ -1,2 +1,3 @@
 fileFormatVersion: 2
-guid: 636c9d36-69c1-42f3-8410-4fddca0c04dd
+guid: 636c9d3669c142f384104fddca0c04dd
+


### PR DESCRIPTION
## Summary
- fix `MapPathfindingUtility.cs.meta` so Unity recognizes the script

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688b4dc5ef508324b4d010b6dde3e35f