### PR TITLE
Add TODO notes for cleanup

### DIFF
--- a/Assets/Scripts/AudioManager.cs
+++ b/Assets/Scripts/AudioManager.cs
@@ -262,6 +262,7 @@ public class AudioManager : MonoBehaviour
     {
         if (backgroundMusic.Length == 0) return;
 
+        // TODO: Preload next track for seamless transition in shuffle mode
         if (shuffleMusic)
             currentMusicIndex = Random.Range(0, backgroundMusic.Length);
         

--- a/Assets/Scripts/Environment/MovingPlatform.cs
+++ b/Assets/Scripts/Environment/MovingPlatform.cs
@@ -18,6 +18,7 @@ namespace RollABall.Environment
         [SerializeField] private float bounceReturn1 = 0.75f;
         [SerializeField] private float bounceReturn2 = 0.9375f;
         [SerializeField] private float bounceReturn3 = 0.984375f;
+        // TODO: Move bounce parameters into MovingPlatformProfile for consistency
 
         [Header("Bewegungseinstellungen")]
         [SerializeField] private Vector3 startPosition;

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -33,6 +33,7 @@ public class GameManager : MonoBehaviour
     private float gameTimeScale = 1f;
     [SerializeField, HideInInspector] private KeyCode pauseKey = KeyCode.Escape; // moved to InputManager
     [SerializeField, HideInInspector] private KeyCode restartKey = KeyCode.R;
+    // TODO: Remove legacy key fields once InputManager fully manages bindings
 
     [Header("Player Reference")]
     [SerializeField] private PlayerController player;

--- a/Assets/Scripts/Input/InputManager.cs
+++ b/Assets/Scripts/Input/InputManager.cs
@@ -222,6 +222,7 @@ namespace RollABall.InputSystem
                 }
             }
             waitingForKey = false;
+            // TODO: Switch to Input System events to capture keys without polling
         }
     }
 }

--- a/Assets/Scripts/Map/AddressResolver.cs
+++ b/Assets/Scripts/Map/AddressResolver.cs
@@ -17,6 +17,7 @@ namespace RollABall.Map
         [Header("API Configuration")]
         [SerializeField] private string nominatimBaseUrl = "https://nominatim.openstreetmap.org";
         [SerializeField] private string overpassBaseUrl = "https://overpass-api.de/api/interpreter";
+        // TODO: Move API URLs to a configuration asset for easier editing
         [SerializeField] private float searchRadius = 500.0f; // meters
         
         [Header("Request Settings")]

--- a/Assets/Scripts/SaveSystem.cs
+++ b/Assets/Scripts/SaveSystem.cs
@@ -184,6 +184,7 @@ public class SaveSystem : MonoBehaviour
     /// </summary>
     public async void SaveCurrentGame()
     {
+        // TODO: Return Task instead of async void to allow awaiting errors
         if (currentSave == null)
         {
             LogSave("No save data to save!", true);

--- a/Assets/Scripts/Testing/OSMTestController.cs
+++ b/Assets/Scripts/Testing/OSMTestController.cs
@@ -241,8 +241,9 @@ namespace RollABall.Testing
         private bool IsPositionReasonable(Vector3 position)
         {
             // Consider positions reasonable if they're within -100 to +100 in each axis
-            return Mathf.Abs(position.x) <= 100f && 
-                   Mathf.Abs(position.y) <= 100f && 
+            // TODO: Replace magic value with configurable boundary constant
+            return Mathf.Abs(position.x) <= 100f &&
+                   Mathf.Abs(position.y) <= 100f &&
                    Mathf.Abs(position.z) <= 100f;
         }
         

--- a/CodeReview_TODOs.md
+++ b/CodeReview_TODOs.md
@@ -55,3 +55,10 @@ The following TODO comments were added during code review to highlight potential
 | Assets/Scripts/SceneTypeDetector.cs | 10 | Allow overriding scene lists at runtime via config file | **done** |
 | Assets/Scripts/Input/InputManager.cs | 25 | Support gamepad bindings alongside keyboard controls | **done** |
 | Assets/Scripts/SaveSystem.cs | 667 | Create incremental backup before uploading to cloud | **done** |
+| Assets/Scripts/GameManager.cs | 36 | Remove legacy key fields once InputManager fully manages bindings | |
+| Assets/Scripts/SaveSystem.cs | 187 | Return Task instead of async void to allow awaiting errors | |
+| Assets/Scripts/Map/AddressResolver.cs | 20 | Move API URLs to a configuration asset for easier editing | |
+| Assets/Scripts/Environment/MovingPlatform.cs | 21 | Move bounce parameters into MovingPlatformProfile for consistency | |
+| Assets/Scripts/Testing/OSMTestController.cs | 244 | Replace magic value with configurable boundary constant | |
+| Assets/Scripts/Input/InputManager.cs | 225 | Switch to Input System events to capture keys without polling | |
+| Assets/Scripts/AudioManager.cs | 265 | Preload next track for seamless transition in shuffle mode | |


### PR DESCRIPTION
## Summary
- insert TODO note about removing legacy key bindings
- flag async void in `SaveSystem`
- suggest config asset for API URLs
- note moving platform bounce parameters should be in profile
- mark magic constant in OSM test controller
- recommend event-based key capture in `InputManager`
- note preloading next music track in `AudioManager`
- record these TODOs in `CodeReview_TODOs.md`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688b508f61b483249db3397c74a8f408