### PR TITLE
Add review TODOs for maintainability

### DIFF
--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -1,5 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+# TODO: Consolidate Player.prefab and PlayerPrefab.prefab into a single prefab
 --- !u!1 &8554796287664602159
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Level2.unity
+++ b/Assets/Scenes/Level2.unity
@@ -1,5 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+# TODO: Replace manual objects with prefab instances for consistency
 --- !u!29 &1
 OcclusionCullingSettings:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/AudioManager.cs
+++ b/Assets/Scripts/AudioManager.cs
@@ -214,6 +214,7 @@ public class AudioManager : MonoBehaviour
 
     public void PlaySoundAtPlayer(string soundName)
     {
+        // TODO: Cache player reference instead of using FindFirstObjectByType each call
         PlayerController player = FindFirstObjectByType<PlayerController>();
         if (player)
             PlaySound(soundName, player.transform.position, player.transform);
@@ -223,9 +224,10 @@ public class AudioManager : MonoBehaviour
 
     public void StopSound(string soundName)
     {
+        // TODO: Track playing sources in a dictionary to avoid full scan here
         foreach (var source in allSources)
         {
-            if (source.isPlaying && soundDictionary.ContainsKey(soundName) && 
+            if (source.isPlaying && soundDictionary.ContainsKey(soundName) &&
                 source.clip == soundDictionary[soundName].clip)
             {
                 source.Stop();

--- a/Assets/Scripts/Map/MapGenerator.cs
+++ b/Assets/Scripts/Map/MapGenerator.cs
@@ -1640,6 +1640,7 @@ namespace RollABall.Map
         {
             if (mapContainer != null)
             {
+                // TODO: Consider pooling map elements instead of destroying them here
                 foreach (Transform child in mapContainer)
                 {
                     if (Application.isPlaying)

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -482,6 +482,7 @@ public class PlayerController : MonoBehaviour
 
     private void ShowDebugInfo()
     {
+        // TODO: Replace Debug.Log spam with a dedicated debug overlay
         Debug.Log($"Ball Status - Grounded: {isGrounded}, Flying: {IsFlying}, Speed: {rb.linearVelocity.magnitude:F2}");
         Debug.Log($"Input: {movementInput}, Jump: {jumpPressed}, Fly: {flyPressed}");
         Debug.Log($"Fly Energy: {flyEnergy:F2}/{maxFlyEnergy}");

--- a/CodeReview_TODOs.md
+++ b/CodeReview_TODOs.md
@@ -62,3 +62,9 @@ The following TODO comments were added during code review to highlight potential
 | Assets/Scripts/Testing/OSMTestController.cs | 244 | Replace magic value with configurable boundary constant | |
 | Assets/Scripts/Input/InputManager.cs | 225 | Switch to Input System events to capture keys without polling | |
 | Assets/Scripts/AudioManager.cs | 265 | Preload next track for seamless transition in shuffle mode | |
+| Assets/Scripts/AudioManager.cs | 217 | Cache player reference instead of using FindFirstObjectByType | |
+| Assets/Scripts/AudioManager.cs | 224 | Maintain map of playing sources for efficient StopSound lookup | |
+| Assets/Scripts/PlayerController.cs | 485 | Replace Debug.Log spam with debug overlay | |
+| Assets/Prefabs/Player.prefab | 2 | Consolidate duplicate player prefabs | |
+| Assets/Scenes/Level2.unity | 2 | Ensure all objects are prefab instances | |
+| Assets/Scripts/Map/MapGenerator.cs | 1643 | Pool map elements instead of destroying them each regeneration | |


### PR DESCRIPTION
## Summary
- add TODO for caching player reference and for tracking playing audio sources
- note debugging overlay in PlayerController
- mark duplicate Player prefab and prefab usage in Level2 scene
- suggest pooling when clearing generated maps
- document new TODOs in CodeReview_TODOs.md

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b53e6a5f08324ac9c98bfbc7e4c13