### PR TITLE
Fix OSM ground duplication and UI handling

### DIFF
--- a/Assets/Scripts/Map/AddressResolver.cs
+++ b/Assets/Scripts/Map/AddressResolver.cs
@@ -562,7 +562,11 @@ namespace RollABall.Map
                 
                 // Validate and set appropriate scale based on area size
                 double areaWidth = maxLon - minLon;
-                mapData.scaleMultiplier = (float)(1000.0 / (areaWidth * 111320.0)); // Scale to reasonable Unity size
+                double areaHeight = maxLat - minLat;
+                double maxExtent = System.Math.Max(areaWidth, areaHeight);
+                const float unityScale = 1000f; // Target size in Unity units
+                // TODO-OPT#94: make map scale configurable via ScriptableObject
+                mapData.scaleMultiplier = (float)(unityScale / (maxExtent * 111320.0)); // Scale to reasonable Unity size
                 
                 Debug.Log($"[AddressResolver] Successfully parsed OSM data: {mapData.roads.Count} roads, {mapData.buildings.Count} buildings, {mapData.areas.Count} areas, {mapData.pointsOfInterest.Count} POIs");
                 

--- a/Assets/Scripts/Map/MapStartupController.cs
+++ b/Assets/Scripts/Map/MapStartupController.cs
@@ -238,7 +238,9 @@ namespace RollABall.Map
                 LogDebug("Already loading, ignoring request");
                 return;
             }
-            
+
+            ClearExistingLevel();
+
             currentAddress = address;
             currentRetries = 0;
             
@@ -274,6 +276,8 @@ namespace RollABall.Map
                 LogDebug("Already loading, ignoring request");
                 return;
             }
+
+            ClearExistingLevel();
             
             LogDebug($"Loading map for coordinates: {latitude}, {longitude}");
             UpdateStatus($"Loading map for coordinates: {latitude:F4}, {longitude:F4}");
@@ -756,9 +760,28 @@ namespace RollABall.Map
         {
             if (statusText)
                 statusText.text = message;
-            
+
             LogDebug($"Status: {message}");
             OnStatusUpdate?.Invoke(message);
+        }
+
+        // TODO-OPT#92: Replace destructive cleanup with pooled map objects
+        private void ClearExistingLevel()
+        {
+            GameObject existingMap = GameObject.Find("GeneratedMap");
+            if (existingMap)
+            {
+                Destroy(existingMap);
+            }
+
+            GameObject[] fallbackObjects = GameObject.FindObjectsOfType<GameObject>();
+            foreach (var obj in fallbackObjects)
+            {
+                if (obj.name.StartsWith("OSM_"))
+                {
+                    Destroy(obj);
+                }
+            }
         }
         
         private void HideMapUI()
@@ -770,7 +793,25 @@ namespace RollABall.Map
                 inputPanel.SetActive(false);
                 LogDebug("Hidden AddressInputPanel");
             }
-            
+
+            if (addressInputField)
+                addressInputField.gameObject.SetActive(false);
+
+            if (loadMapButton)
+                loadMapButton.gameObject.SetActive(false);
+
+            if (useCurrentLocationButton)
+                useCurrentLocationButton.gameObject.SetActive(false);
+
+            if (regenerateMapButton)
+                regenerateMapButton.gameObject.SetActive(false);
+
+            if (loadingPanel)
+                loadingPanel.SetActive(false);
+
+            if (statusText)
+                statusText.gameObject.SetActive(false);
+
             // Also try the canvas approach (from remote)
             Canvas canvas = GetComponentInParent<Canvas>();
             if (canvas && inputPanel == null)
@@ -797,7 +838,25 @@ namespace RollABall.Map
                 inputPanel.SetActive(true);
                 LogDebug("Shown AddressInputPanel");
             }
-            
+
+            if (addressInputField)
+                addressInputField.gameObject.SetActive(true);
+
+            if (loadMapButton)
+                loadMapButton.gameObject.SetActive(true);
+
+            if (useCurrentLocationButton)
+                useCurrentLocationButton.gameObject.SetActive(true);
+
+            if (regenerateMapButton)
+                regenerateMapButton.gameObject.SetActive(true);
+
+            if (loadingPanel)
+                loadingPanel.SetActive(false);
+
+            if (statusText)
+                statusText.gameObject.SetActive(true);
+
             // Also try the canvas approach
             Canvas canvas = GetComponentInParent<Canvas>();
             if (canvas && !canvas.gameObject.activeInHierarchy)

--- a/OSM_Level_Generation.md
+++ b/OSM_Level_Generation.md
@@ -1,0 +1,13 @@
+# OSM Level Generation Improvements
+
+This document summarises recent changes to the OpenStreetMap based level generation.
+
+## Ground Cleanup
+- `MapStartupController` destroys any previously generated ground or fallback objects via `ClearExistingLevel`. This prevents stacked `GroundPlane` objects when a new map is loaded.
+
+## Consistent Scale
+- `AddressResolver.ParseOSMResponse` now calculates `scaleMultiplier` using the largest extent of the requested area. The map is scaled to approximately 1000 Unity units regardless of bounding box orientation.
+
+## UI Handling
+- After a map finishes loading, input controls and loading indicators are deactivated. They are re-enabled when calling `ShowMapUI`.
+

--- a/TODO_Index.md
+++ b/TODO_Index.md
@@ -93,3 +93,6 @@
 | TODO-OPT#89 | Assets/Scripts/Environment/SwitchTrigger.cs | Awake(), Zeile 32 | Warn if gate missing | **erledigt** |
 | TODO-OPT#90 | Assets/Scripts/Environment/SwitchTrigger.cs | ActivateSwitch(), Zeile 83 | Reset/deactivation logic | **erledigt** |
 | TODO-OPT#91 | Assets/Scripts/Environment/SwitchTrigger.cs | OnValidate(), Zeile 93 | Highlight object when gate missing | **erledigt** |
+| TODO-OPT#92 | Assets/Scripts/Map/MapStartupController.cs | ClearExistingLevel(), Zeile 758 | Replace destructive cleanup with pooled map objects |
+| TODO-OPT#93 | Assets/Scripts/Map/MapStartupController.cs | HideMapUI(), Zeile 789 | Ensure UI references are serialized rather than searched |
+| TODO-OPT#94 | Assets/Scripts/Map/AddressResolver.cs | ParseOSMResponse(), Zeile 567 | Make map scale configurable via ScriptableObject |


### PR DESCRIPTION
## Summary
- prevent leftover ground objects when loading new OSM maps
- scale maps consistently using max bounding box extent
- hide address UI elements when the map is loaded
- document OSM level generation behaviour
- track cleanup TODOs in `TODO_Index.md`

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_688b8f4ef4048324a2cee5b0b6882b0b