### PR TITLE
Fix MovingPlatform prefab warning

### DIFF
--- a/Assets/Prefabs/Steampunk/MovingPlatform.prefab
+++ b/Assets/Prefabs/Steampunk/MovingPlatform.prefab
@@ -1,6 +1,7 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
 # TODO: Test new movement patterns before finalizing prefab
+# v1
 --- !u!1 &100000
 GameObject:
   m_ObjectHideFlags: 0
@@ -13,6 +14,7 @@ GameObject:
   - component: {fileID: 100002}
   - component: {fileID: 100003}
   - component: {fileID: 100004}
+  - component: {fileID: 100005}
   m_Layer: 0
   m_Name: MovingPlatform
   m_TagString: MovingPlatform
@@ -70,6 +72,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 609abd01176e68b009fce9e54383568d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   profile: {fileID: 0}
+  startPosition: {x: 0, y: 0, z: 0}
+  endPosition: {x: 0, y: 3, z: 0}


### PR DESCRIPTION
## Summary
- include missing MonoBehaviour component in MovingPlatform prefab
- define start and end positions so OnValidate stops warning
- note prefab version

## Testing
- `unity-editor -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ca0f4637c8324b1c79c40fcfa8f65