### PR TITLE
Add TODO notes from review

### DIFF
--- a/Assets/Scenes/GeneratedLevel_backup.unity
+++ b/Assets/Scenes/GeneratedLevel_backup.unity
@@ -1,5 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+# TODO: Archive or delete this backup scene before release
 --- !u!29 &1
 OcclusionCullingSettings:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Level1_backup.unity
+++ b/Assets/Scenes/Level1_backup.unity
@@ -1,5 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+# TODO: Archive or delete this backup scene before release
 --- !u!29 &1
 OcclusionCullingSettings:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/LevelDatabase.cs
+++ b/Assets/Scripts/LevelDatabase.cs
@@ -8,4 +8,5 @@ using UnityEngine;
 public class LevelDatabase : ScriptableObject
 {
     public List<LevelInfo> levels = new();
+    // TODO: Add OnValidate to check for duplicate scene names in levels list
 }

--- a/Assets/Scripts/SceneValidator.cs
+++ b/Assets/Scripts/SceneValidator.cs
@@ -52,6 +52,7 @@ public class SceneValidator : MonoBehaviour
     /// </summary>
     public IEnumerator ValidateSceneAsync()
     {
+        // TODO: Split validation categories into separate modular validator classes
         LogValidation("🔍 Starting comprehensive scene validation...", true);
 
         int totalSteps = 0;
@@ -561,8 +562,9 @@ public class SceneValidator : MonoBehaviour
     
     private void SaveValidationReport()
     {
-        string reportPath = "/home/saschi/Games/Roll-a-Ball/Reports/ValidationReport_" + 
-                           validationReport.sceneName + "_" + 
+        // TODO: Allow configuring output directory via ScriptableObject
+        string reportPath = "/home/saschi/Games/Roll-a-Ball/Reports/ValidationReport_" +
+                           validationReport.sceneName + "_" +
                            System.DateTime.Now.ToString("yyyy-MM-dd_HH-mm-ss") + ".md";
         
         string report = GenerateMarkdownReport();

--- a/Assets/Scripts/Utility/ColliderPooler.cs
+++ b/Assets/Scripts/Utility/ColliderPooler.cs
@@ -11,6 +11,7 @@ namespace RollABall.Utility
     {
         private static readonly Queue<GameObject> meshPool = new();
         private static readonly Queue<GameObject> boxPool = new();
+        // TODO: Add maximum pool size and prewarm option to control memory usage
 
         /// <summary>
         /// Get a pooled collider object. If <paramref name="useMeshCollider"/> is

--- a/Assets/Scripts/Utility/LevelProgressionSetup.cs
+++ b/Assets/Scripts/Utility/LevelProgressionSetup.cs
@@ -81,6 +81,7 @@ public static class LevelProgressionSetup
     private static void CreateLevelProgressionProfileMenu()
     {
         CreateDefaultLevelProgression();
+        // TODO: Automatically add new profile to build settings if scenes missing
     }
     
     /// <summary>

--- a/Assets/Scripts/Utility/SceneObjectUtils.cs
+++ b/Assets/Scripts/Utility/SceneObjectUtils.cs
@@ -17,6 +17,7 @@ namespace RollABall.Utility
                 return existing;
 
             var go = new GameObject(string.IsNullOrEmpty(objectName) ? typeof(T).Name : objectName);
+            // TODO: Allow optional parent transform to avoid cluttering scene root
             return go.AddComponent<T>();
         }
     }

--- a/CodeReview_TODOs.md
+++ b/CodeReview_TODOs.md
@@ -114,3 +114,11 @@ The following TODO comments were added during code review to highlight potential
 | Assets/Resources/AddressLists/EndlessAddresses.asset | 3 | Support dynamic address sets loaded from server | |
 | Assets/Scenes/GeneratedLevel.unity | 4 | Remove scene once runtime generator is stable | |
 | Assets/ScriptableObjects/DefaultTagConfig.asset | 3 | Allow runtime extension of tags for mods | |
+| Assets/Scripts/LevelDatabase.cs | 11 | Add OnValidate to check for duplicate scene names | |
+| Assets/Scripts/Utility/ColliderPooler.cs | 14 | Add maximum pool size and prewarm option to control memory usage | |
+| Assets/Scripts/Utility/SceneObjectUtils.cs | 20 | Allow optional parent transform to avoid cluttering scene root | |
+| Assets/Scripts/Utility/LevelProgressionSetup.cs | 84 | Automatically add new profile to build settings if scenes missing | |
+| Assets/Scripts/SceneValidator.cs | 55 | Split validation categories into modular validator classes | |
+| Assets/Scripts/SceneValidator.cs | 565 | Allow configuring output directory via ScriptableObject | |
+| Assets/Scenes/Level1_backup.unity | 3 | Archive or delete this backup scene before release | |
+| Assets/Scenes/GeneratedLevel_backup.unity | 3 | Archive or delete this backup scene before release | |


### PR DESCRIPTION
## Summary
- annotate LevelDatabase for duplicate scene validation
- flag improvements in collider pooling and utility helpers
- mark LevelProgressionSetup for build settings automation
- suggest modularizing SceneValidator and customizing report path
- remind cleanup of backup scenes
- log new TODOs in `CodeReview_TODOs.md`

## Testing
- `Running linter (none configured)`

------
https://chatgpt.com/codex/tasks/task_e_688ca0eadee48324961462430b4a2374