### PR TITLE
Fix child references in GameUI prefab

### DIFF
--- a/Assets/Resources/Prefabs/UI/GameUI.prefab
+++ b/Assets/Resources/Prefabs/UI/GameUI.prefab
@@ -31,7 +31,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 9206532335342873135}
+  - {fileID: 6154266117893550244}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -130,7 +130,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 8476918561051873467}
+  - {fileID: 6106058055313421365}
   m_Father: {fileID: 6398834228380159140}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}


### PR DESCRIPTION
## Summary
- correct RectTransform child references in GameUI prefab to use component file IDs

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891f91a88608324b79f605f3352ff24