### PR TITLE
fix: unique collectible tracking and UI prefab loading

### DIFF
--- a/TODO_Index.md
+++ b/TODO_Index.md
@@ -99,3 +99,5 @@
 | TODO-OPT#95 | Assets/Scripts/Generators/LevelTerrainGenerator.cs | GeneratePrimMaze(), Zeile 358 | Evaluate Prim algorithm performance for large level sizes | |
 | TODO-OPT#96 | Assets/Scripts/UIController.cs | EnsureCollectibleCounter(), Zeile 193 | UI prefab should load via Addressables instead of Resources | |
 | TODO-OPT#97 | Assets/Scripts/CollectibleController.cs | CollectibleData.isCollected, Zeile 16 | Merge duplicate collection flags into single source of truth | |
+| TODO-OPT#98 | Assets/Scripts/LevelManager.cs | InitializeLevelManager(), Zeile 143 | Load UI prefab via Addressables instead of Resources | |
+| TODO-OPT#99 | Assets/Scripts/LevelManager.cs | UpdateCollectibleCount(), Zeile 223 | Cache counts to avoid repeated HashSet scans | |


### PR DESCRIPTION
## Summary
- prevent doubled collectible counts with a `HashSet` and safe event handling
- auto-load shared `GameUI` prefab when scenes lack UI
- document follow-up improvements in TODO index

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891fc1b07f08324bb2be70635ed905a