### PR TITLE
fix collectible tracking and unify ui

### DIFF
--- a/Assets/Scripts/UIController.cs
+++ b/Assets/Scripts/UIController.cs
@@ -236,14 +236,19 @@ public bool IsGameUIActive => gameUIPanel && gameUIPanel.activeSelf;
                 var textObject = new GameObject("CollectibleText", typeof(TextMeshProUGUI));
                 textObject.transform.SetParent(gameUIPanel.transform, false);
                 collectibleCountText = textObject.GetComponent<TextMeshProUGUI>();
-                collectibleCountText.text = "Collectibles: 0/0";
             }
         }
 
-        var rect = collectibleCountText.rectTransform;
-        rect.anchorMin = rect.anchorMax = new Vector2(0f, 1f);
-        rect.pivot = new Vector2(0f, 1f);
-        rect.anchoredPosition = new Vector2(20f, -20f);
+        if (collectibleCountText)
+        {
+            if (string.IsNullOrEmpty(collectibleCountText.text))
+                collectibleCountText.text = "Collectibles: 0/0"; // UI FIX: consistent default text
+
+            var rect = collectibleCountText.rectTransform;
+            rect.anchorMin = rect.anchorMax = new Vector2(0f, 1f);
+            rect.pivot = new Vector2(0f, 1f);
+            rect.anchoredPosition = new Vector2(20f, -20f);
+        }
     }
     
     private void SetupEventListeners()
@@ -306,9 +311,11 @@ public bool IsGameUIActive => gameUIPanel && gameUIPanel.activeSelf;
             GameManager.Instance.OnGameStateChanged += OnGameStateChanged;
             GameManager.Instance.OnStatisticsUpdated += OnStatisticsUpdated;
         }
-        
+
         if (LevelManager.Instance)
         {
+            LevelManager.Instance.OnLevelCompleted -= OnLevelCompleted; // UI FIX: prevent double subscription
+            LevelManager.Instance.OnCollectibleCountChanged -= OnCollectibleCountChanged; // UI FIX
             LevelManager.Instance.OnLevelCompleted += OnLevelCompleted;
             LevelManager.Instance.OnCollectibleCountChanged += OnCollectibleCountChanged;
         }

--- a/TODO_Index.md
+++ b/TODO_Index.md
@@ -101,3 +101,4 @@
 | TODO-OPT#97 | Assets/Scripts/CollectibleController.cs | CollectibleData.isCollected, Zeile 16 | Merge duplicate collection flags into single source of truth | |
 | TODO-OPT#98 | Assets/Scripts/LevelManager.cs | InitializeLevelManager(), Zeile 143 | Load UI prefab via Addressables instead of Resources | |
 | TODO-OPT#99 | Assets/Scripts/LevelManager.cs | UpdateCollectibleCount(), Zeile 223 | Cache counts to avoid repeated HashSet scans | |
+| TODO-OPT#100 | Assets/Scripts/LevelManager.cs | collectedCollectibles, Zeile 55 | Pool HashSet to minimize allocations when resetting levels | |


### PR DESCRIPTION
## Summary
- ensure collectible counts increment correctly by tracking collected items and updating level progression
- standardize runtime UI creation from GameUI prefab and guard against double event subscriptions
- document future optimization for collectible tracking

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-6.0` *(fails: Package has no installation candidate)*

------
https://chatgpt.com/codex/tasks/task_e_689200e6b5288324970bd69d2a8dc808