### PR TITLE
Replace Addressables with Resources for UI prefabs

### DIFF
--- a/Assets/Scripts/LevelManager.cs
+++ b/Assets/Scripts/LevelManager.cs
@@ -3,8 +3,6 @@ using UnityEngine.SceneManagement;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using UnityEngine.AddressableAssets;
-using UnityEngine.ResourceManagement.AsyncOperations;
 
 /// <summary>
 /// Manages level progression, collectible tracking, and scene transitions
@@ -162,9 +160,7 @@ public class LevelManager : MonoBehaviour
             uiController = FindFirstObjectByType<UIController>();
             if (!uiController)
             {
-                AsyncOperationHandle<GameObject> handle = Addressables.LoadAssetAsync<GameObject>("GameUI");
-                GameObject uiPrefab = handle.WaitForCompletion();
-                Addressables.Release(handle);
+                GameObject uiPrefab = Resources.Load<GameObject>("Prefabs/UI/GameUI");
                 if (uiPrefab)
                 {
                     var uiInstance = Instantiate(uiPrefab); // UI FIX: centralize UI via prefab

--- a/Assets/Scripts/UIController.cs
+++ b/Assets/Scripts/UIController.cs
@@ -4,8 +4,6 @@ using TMPro;
 using System.Collections.Generic;
 using System.Collections;
 using System.Linq;
-using UnityEngine.AddressableAssets;
-using UnityEngine.ResourceManagement.AsyncOperations;
 
 /// <summary>
 /// UI Controller for Roll-a-Ball with progression features
@@ -195,9 +193,7 @@ public bool IsGameUIActive => gameUIPanel && gameUIPanel.activeSelf;
             GameObject prefab = gameUIPrefab;
             if (!prefab)
             {
-                AsyncOperationHandle<GameObject> handle = Addressables.LoadAssetAsync<GameObject>("GameUI");
-                prefab = handle.WaitForCompletion();
-                Addressables.Release(handle);
+                prefab = Resources.Load<GameObject>("Prefabs/UI/GameUI");
             }
             if (prefab)
             {


### PR DESCRIPTION
## Summary
- Remove Addressables namespace usage in LevelManager and UIController
- Load GameUI prefab using Resources instead of Addressables to avoid missing assembly errors

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*


------
https://chatgpt.com/codex/tasks/task_e_689210615a2483249d35948ce05db263