### PR TITLE
fix: resolve Debug ambiguity in terrain generator

### DIFF
--- a/Assets/Scripts/Generators/LevelTerrainGenerator.cs
+++ b/Assets/Scripts/Generators/LevelTerrainGenerator.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Collections;
 using System.Linq;
 using System;
-using System.Diagnostics;
 
 namespace RollABall.Generators
 {
@@ -348,9 +347,9 @@ namespace RollABall.Generators
     {
         int size = profile.LevelSize;
 
-        Stopwatch stopwatch = null;
+        System.Diagnostics.Stopwatch stopwatch = null;
         if (size >= 50)
-            stopwatch = Stopwatch.StartNew();
+            stopwatch = System.Diagnostics.Stopwatch.StartNew();
 
         // Initialize grid with walls
         for (int x = 1; x < size - 1; x++)


### PR DESCRIPTION
## Summary
- remove System.Diagnostics using to avoid UnityEngine.Debug conflict
- fully qualify Stopwatch usage in LevelTerrainGenerator

## Testing
- `dotnet build` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_689212543b3c8324829221dfcf448dfe