### PR TITLE
fix: sync collectible counters across levels

### DIFF
--- a/Assets/Scripts/Generators/LevelGenerator.cs
+++ b/Assets/Scripts/Generators/LevelGenerator.cs
@@ -872,6 +872,10 @@ public class LevelGenerator : MonoBehaviour
             {
                 Debug.Log($"[LevelGenerator] Updated LevelManager configuration");
             }
+
+            levelManager.RescanCollectibles(); // COLLECTIBLE COUNTER SYNC
+            if (showGenerationDebug)
+                Debug.Log("[LevelGenerator] Rescanned LevelManager collectibles");
         }
 
         // Update UI if necessary

--- a/Assets/Scripts/LevelManager.cs
+++ b/Assets/Scripts/LevelManager.cs
@@ -193,6 +193,8 @@ public class LevelManager : MonoBehaviour
 
         // Update collectible count
         UpdateCollectibleCount();
+        if (debugMode)
+            Debug.Log($"[LevelManager] Counters reset: {levelConfig.collectiblesRemaining}/{levelConfig.totalCollectibles}"); // COLLECTIBLE COUNTER SYNC
 
         // Subscribe to collectible events
         SubscribeToCollectibleEvents();
@@ -269,9 +271,27 @@ public class LevelManager : MonoBehaviour
         {
             levelConfig.totalCollectibles = levelCollectibles.Count;
             initialCollectibleCount = levelConfig.totalCollectibles;
+            if (debugMode)
+                Debug.Log($"[LevelManager] Total collectibles set to {levelConfig.totalCollectibles}"); // COLLECTIBLE COUNTER SYNC
         }
 
         levelConfig.collectiblesRemaining = Mathf.Max(0, levelConfig.totalCollectibles - collectedCountCache);
+        if (debugMode)
+            Debug.Log($"[LevelManager] Collectibles remaining: {levelConfig.collectiblesRemaining}/{levelConfig.totalCollectibles}"); // COLLECTIBLE COUNTER SYNC
+    }
+
+    /// <summary>
+    /// Rebuilds collectible tracking and synchronizes counts.
+    /// </summary>
+    public void RescanCollectibles()
+    {
+        UnsubscribeFromCollectibleEvents();
+        FindAllCollectibles();
+        UpdateCollectibleCount();
+        SubscribeToCollectibleEvents();
+        UpdateUI();
+        if (debugMode)
+            Debug.Log($"[LevelManager] Rescanned collectibles: {levelConfig.collectiblesRemaining}/{levelConfig.totalCollectibles}"); // COLLECTIBLE COUNTER SYNC
     }
 
     private void SubscribeToCollectibleEvents()
@@ -443,6 +463,8 @@ public class LevelManager : MonoBehaviour
         if (!string.IsNullOrEmpty(levelConfig.nextSceneName))
         {
             // Load specific next scene
+            if (debugMode)
+                Debug.Log($"[LevelManager] Loading next level: {levelConfig.nextSceneName}"); // LEVEL PROGRESSION FIX
             SceneManager.LoadScene(levelConfig.nextSceneName);
         }
         else
@@ -453,6 +475,8 @@ public class LevelManager : MonoBehaviour
             
             if (!string.IsNullOrEmpty(nextScene))
             {
+                if (debugMode)
+                    Debug.Log($"[LevelManager] Loading next level: {nextScene}"); // LEVEL PROGRESSION FIX
                 SceneManager.LoadScene(nextScene);
             }
             else

--- a/Assets/Scripts/Map/MapGenerator.cs
+++ b/Assets/Scripts/Map/MapGenerator.cs
@@ -572,8 +572,8 @@ namespace RollABall.Map
                         levelManager.AddCollectible(collectible);
                     }
                 }
-                // COLLECTIBLE FIX: ensure counts reflect all spawned collectibles
-                levelManager.UpdateCollectibleCount();
+                // COLLECTIBLE COUNTER SYNC: refresh LevelManager with spawned collectibles
+                levelManager.RescanCollectibles();
 
                 Debug.Log($"[MapGenerator] Added {collectibles.Length} collectibles to LevelManager");
             }

--- a/Assets/Scripts/Map/MapGeneratorBatched.cs
+++ b/Assets/Scripts/Map/MapGeneratorBatched.cs
@@ -945,11 +945,11 @@ namespace RollABall.Map
                     yield return null;
             }
             
-            // Update UI if LevelManager exists
+            // COLLECTIBLE COUNTER SYNC: update LevelManager with spawned collectibles
             LevelManager levelManager = FindFirstObjectByType<LevelManager>();
             if (levelManager != null)
             {
-                levelManager.UpdateCollectibleCount();
+                levelManager.RescanCollectibles();
             }
             
             yield return null;

--- a/wiki/docs/development/TODO_Index.md
+++ b/wiki/docs/development/TODO_Index.md
@@ -103,3 +103,7 @@
 | TODO-OPT#99 | Assets/Scripts/LevelManager.cs | UpdateCollectibleCount(), Zeile 223 | Cache counts to avoid repeated HashSet scans | **erledigt** |
 | TODO-OPT#100 | Assets/Scripts/LevelManager.cs | collectedCollectibles, Zeile 55 | Pool HashSet to minimize allocations when resetting levels | **erledigt** |
 | TODO-OPT#101 | Assets/Scripts/Editor/UIPrefabSceneUpdater.cs | UpdateUIPrefabInAllScenes(), Zeile 12 | Preserve custom UI elements during automatic replacement | offen |
+| TODO-OPT#102 | Assets/Scripts/LevelManager.cs | RescanCollectibles(), Zeile 233 | Rebuild collectible tracking after procedural generation | **erledigt** |
+| TODO-OPT#103 | Assets/Scripts/Generators/LevelGenerator.cs | IntegrateWithGameSystems(), Zeile 860 | Refresh LevelManager after generating collectibles | **erledigt** |
+| TODO-OPT#104 | Assets/Scripts/Map/MapGenerator.cs | AddGeneratedCollectibles(), Zeile 565 | Synchronize LevelManager with spawned collectibles | **erledigt** |
+| TODO-OPT#105 | Assets/Scripts/Map/MapGeneratorBatched.cs | GenerateCollectibleObjects(), Zeile 949 | Rescan LevelManager collectible count for batched maps | **erledigt** |


### PR DESCRIPTION
## Summary
- ensure LevelManager rescans collectibles to sync counts and progression
- rescan collectible counts after procedural or OSM level generation
- document collectible sync responsibilities in TODO index

## Testing
- `dotnet test` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68922d4cfc988324b48b4c477f468dda