### PR TITLE
fix: prevent duplicate collectible events

### DIFF
--- a/Assets/Scripts/AchievementSystem.cs
+++ b/Assets/Scripts/AchievementSystem.cs
@@ -294,11 +294,17 @@ public class AchievementSystem : MonoBehaviour
             GameManager.Instance.OnGameStateChanged += OnGameStateChanged;
             GameManager.Instance.OnStatisticsUpdated += OnStatisticsUpdated;
         }
-        
+
         if (LevelManager.Instance)
         {
-            LevelManager.Instance.OnLevelCompleted += OnLevelCompleted;
-            LevelManager.Instance.OnCollectibleCountChanged += OnCollectibleCountChanged;
+            LevelManager.Instance.OnLevelCompleted -= OnLevelCompleted; // EVENT DOUBLE-FIRE FIX
+            Debug.Log("Unregistered OnLevelCompleted"); // EVENT DOUBLE-FIRE FIX
+            LevelManager.Instance.OnCollectibleCountChanged -= OnCollectibleCountChanged; // EVENT DOUBLE-FIRE FIX
+            Debug.Log("Unregistered OnCollectibleCountChanged"); // EVENT DOUBLE-FIRE FIX
+            LevelManager.Instance.OnLevelCompleted += OnLevelCompleted; // EVENT DOUBLE-FIRE FIX
+            Debug.Log("Registered OnLevelCompleted"); // EVENT DOUBLE-FIRE FIX
+            LevelManager.Instance.OnCollectibleCountChanged += OnCollectibleCountChanged; // EVENT DOUBLE-FIRE FIX
+            Debug.Log("Registered OnCollectibleCountChanged"); // EVENT DOUBLE-FIRE FIX
         }
         
         // Subscribe to player events
@@ -321,8 +327,10 @@ public class AchievementSystem : MonoBehaviour
 
         if (LevelManager.Instance)
         {
-            LevelManager.Instance.OnLevelCompleted -= OnLevelCompleted;
-            LevelManager.Instance.OnCollectibleCountChanged -= OnCollectibleCountChanged;
+            LevelManager.Instance.OnLevelCompleted -= OnLevelCompleted; // EVENT DOUBLE-FIRE FIX
+            Debug.Log("Unregistered OnLevelCompleted"); // EVENT DOUBLE-FIRE FIX
+            LevelManager.Instance.OnCollectibleCountChanged -= OnCollectibleCountChanged; // EVENT DOUBLE-FIRE FIX
+            Debug.Log("Unregistered OnCollectibleCountChanged"); // EVENT DOUBLE-FIRE FIX
         }
 
         if (cachedPlayer)

--- a/Assets/Scripts/LevelManager.cs
+++ b/Assets/Scripts/LevelManager.cs
@@ -117,6 +117,11 @@ public class LevelManager : MonoBehaviour
         }
     }
 
+    void OnDisable()
+    {
+        UnsubscribeFromCollectibleEvents(); // EVENT DOUBLE-FIRE FIX
+    }
+
     void OnDestroy()
     {
         // CLAUDE: FIXED - Unsubscribe from collectible events to avoid memory leaks
@@ -306,8 +311,12 @@ public class LevelManager : MonoBehaviour
         {
             if (!collectible) continue;
             collectible.OnCollectiblePickedUp -= OnCollectibleCollected; // COLLECTIBLE COUNTER FIX: avoid duplicate handlers
+            Debug.Log("Unregistered OnCollectibleCollected"); // EVENT DOUBLE-FIRE FIX
             if (subscribe)
-                collectible.OnCollectiblePickedUp += OnCollectibleCollected;
+            {
+                collectible.OnCollectiblePickedUp += OnCollectibleCollected; // EVENT DOUBLE-FIRE FIX
+                Debug.Log("Registered OnCollectibleCollected"); // EVENT DOUBLE-FIRE FIX
+            }
         }
     }
 

--- a/Assets/Scripts/LevelProgressionFixer.cs
+++ b/Assets/Scripts/LevelProgressionFixer.cs
@@ -169,13 +169,17 @@ public class LevelProgressionFixer : MonoBehaviour
     private void SetupProgressionEvents()
     {
         if (!levelManager) return;
-        
+
         Log("Setting up progression events...");
-        
-        // Subscribe to level completion
-        levelManager.OnLevelCompleted += OnLevelCompleted;
-        levelManager.OnCollectibleCountChanged += OnCollectibleCountChanged;
-        
+        levelManager.OnLevelCompleted -= OnLevelCompleted; // EVENT DOUBLE-FIRE FIX
+        Debug.Log("Unregistered OnLevelCompleted"); // EVENT DOUBLE-FIRE FIX
+        levelManager.OnCollectibleCountChanged -= OnCollectibleCountChanged; // EVENT DOUBLE-FIRE FIX
+        Debug.Log("Unregistered OnCollectibleCountChanged"); // EVENT DOUBLE-FIRE FIX
+        levelManager.OnLevelCompleted += OnLevelCompleted; // EVENT DOUBLE-FIRE FIX
+        Debug.Log("Registered OnLevelCompleted"); // EVENT DOUBLE-FIRE FIX
+        levelManager.OnCollectibleCountChanged += OnCollectibleCountChanged; // EVENT DOUBLE-FIRE FIX
+        Debug.Log("Registered OnCollectibleCountChanged"); // EVENT DOUBLE-FIRE FIX
+
         Log("Connected progression events");
     }
 
@@ -512,8 +516,10 @@ public class LevelProgressionFixer : MonoBehaviour
         // Clean up event subscriptions
         if (levelManager)
         {
-            levelManager.OnLevelCompleted -= OnLevelCompleted;
-            levelManager.OnCollectibleCountChanged -= OnCollectibleCountChanged;
+            levelManager.OnLevelCompleted -= OnLevelCompleted; // EVENT DOUBLE-FIRE FIX
+            Debug.Log("Unregistered OnLevelCompleted"); // EVENT DOUBLE-FIRE FIX
+            levelManager.OnCollectibleCountChanged -= OnCollectibleCountChanged; // EVENT DOUBLE-FIRE FIX
+            Debug.Log("Unregistered OnCollectibleCountChanged"); // EVENT DOUBLE-FIRE FIX
         }
     }
 

--- a/Assets/Scripts/UIController.cs
+++ b/Assets/Scripts/UIController.cs
@@ -325,9 +325,13 @@ public bool IsGameUIActive => gameUIPanel && gameUIPanel.activeSelf;
         if (LevelManager.Instance)
         {
             LevelManager.Instance.OnLevelCompleted -= OnLevelCompleted; // UI FIX: prevent double subscription
+            Debug.Log("Unregistered OnLevelCompleted"); // EVENT DOUBLE-FIRE FIX
             LevelManager.Instance.OnCollectibleCountChanged -= OnCollectibleCountChanged; // UI FIX
-            LevelManager.Instance.OnLevelCompleted += OnLevelCompleted;
-            LevelManager.Instance.OnCollectibleCountChanged += OnCollectibleCountChanged;
+            Debug.Log("Unregistered OnCollectibleCountChanged"); // EVENT DOUBLE-FIRE FIX
+            LevelManager.Instance.OnLevelCompleted += OnLevelCompleted; // EVENT DOUBLE-FIRE FIX
+            Debug.Log("Registered OnLevelCompleted"); // EVENT DOUBLE-FIRE FIX
+            LevelManager.Instance.OnCollectibleCountChanged += OnCollectibleCountChanged; // EVENT DOUBLE-FIRE FIX
+            Debug.Log("Registered OnCollectibleCountChanged"); // EVENT DOUBLE-FIRE FIX
         }
     }
     
@@ -1137,9 +1141,11 @@ public bool IsGameUIActive => gameUIPanel && gameUIPanel.activeSelf;
         if (LevelManager.Instance)
         {
             LevelManager.Instance.OnLevelCompleted -= OnLevelCompleted;
+            Debug.Log("Unregistered OnLevelCompleted"); // EVENT DOUBLE-FIRE FIX
             LevelManager.Instance.OnCollectibleCountChanged -= OnCollectibleCountChanged;
+            Debug.Log("Unregistered OnCollectibleCountChanged"); // EVENT DOUBLE-FIRE FIX
         }
-        
+
         // Clear UI item collections
         saveSlotItems?.Clear();
         achievementItems?.Clear();

--- a/wiki/docs/development/TODO_Index.md
+++ b/wiki/docs/development/TODO_Index.md
@@ -109,3 +109,4 @@
 | TODO-OPT#105 | Assets/Scripts/Map/MapGeneratorBatched.cs | GenerateCollectibleObjects(), Zeile 949 | Rescan LevelManager collectible count for batched maps | **erledigt** |
 | TODO-OPT#106 | Assets/Scripts/LevelManager.cs | StartLevel(), Zeile 184 | TotalCollectibles aus Inspector oder Szene zählen | **erledigt** |
 | TODO-OPT#107 | Assets/Scripts/LevelManager.cs | OnCollectibleCollected(), Zeile 326 | Sofortigen Levelwechsel bei kompletter Sammlung auslösen | **erledigt** |
+| TODO-OPT#108 | Assets/Scripts/LevelManager.cs, Assets/Scripts/UIController.cs, Assets/Scripts/AchievementSystem.cs, Assets/Scripts/LevelProgressionFixer.cs | Eventregistrierungen | Event-Registrierungen gegen doppelte Auslösung abgesichert | **erledigt** |


### PR DESCRIPTION
## Summary
- guard LevelManager collectible subscriptions against double registration with debug logs
- ensure progression and achievement systems remove and re-add collectible events safely
- log collectible UI subscriptions and note event safety in TODO index

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_689235a003048324a9260dde63d4929e