### PR TITLE
refactor: centralize collectible event registration

### DIFF
--- a/Assets/Scripts/CollectibleDiagnosticTool.cs
+++ b/Assets/Scripts/CollectibleDiagnosticTool.cs
@@ -338,6 +338,7 @@ public class CollectibleDiagnosticTool : MonoBehaviour
             if (levelManager)
             {
                 levelManager.AddCollectible(collectible);
+                levelManager.RegisterCollectibleEvents(collectible); // EVENT HANDLING CONSOLIDATION
                 Log($"Reconnected '{collectible.name}' to LevelManager");
             }
         }

--- a/Assets/Scripts/Map/MapGenerator.cs
+++ b/Assets/Scripts/Map/MapGenerator.cs
@@ -570,11 +570,9 @@ namespace RollABall.Map
 
                         // Add to LevelManager for event tracking
                         levelManager.AddCollectible(collectible);
+                        levelManager.RegisterCollectibleEvents(collectible); // EVENT HANDLING CONSOLIDATION
                     }
                 }
-                // COLLECTIBLE COUNTER SYNC: refresh LevelManager with spawned collectibles
-                levelManager.RescanCollectibles();
-
                 Debug.Log($"[MapGenerator] Added {collectibles.Length} collectibles to LevelManager");
             }
             else

--- a/wiki/docs/development/TODO_Index.md
+++ b/wiki/docs/development/TODO_Index.md
@@ -110,3 +110,4 @@
 | TODO-OPT#106 | Assets/Scripts/LevelManager.cs | StartLevel(), Zeile 184 | TotalCollectibles aus Inspector oder Szene zählen | **erledigt** |
 | TODO-OPT#107 | Assets/Scripts/LevelManager.cs | OnCollectibleCollected(), Zeile 326 | Sofortigen Levelwechsel bei kompletter Sammlung auslösen | **erledigt** |
 | TODO-OPT#108 | Assets/Scripts/LevelManager.cs, Assets/Scripts/UIController.cs, Assets/Scripts/AchievementSystem.cs, Assets/Scripts/LevelProgressionFixer.cs | Eventregistrierungen | Event-Registrierungen gegen doppelte Auslösung abgesichert | **erledigt** |
+| TODO-OPT#109 | Assets/Scripts/LevelManager.cs | RegisterCollectibleEvents(), Zeile 307 | Event-Registrierung zentral verwalten | **erledigt** |


### PR DESCRIPTION
## Summary
- ensure collectibles register their pickup event only once via new RegisterCollectibleEvents
- remove event subscription from AddCollectible and handle dynamic spawns explicitly
- log event registration and firing; update TODO index

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*


------
https://chatgpt.com/codex/tasks/task_e_689239ac5bb08324bd229215d2965946