### PR TITLE
fix: ensure level progression after collectibles

### DIFF
--- a/Assets/Scripts/LevelManager.cs
+++ b/Assets/Scripts/LevelManager.cs
@@ -587,8 +587,18 @@ public class LevelManager : MonoBehaviour
                 Debug.LogWarning($"RecordLevelPerformance method not available: {e.Message}");
             }
         }
+        StartCoroutine(LoadNextLevelRoutine());
+    }
 
-        Invoke(nameof(LoadNextLevel), 0.2f);
+    /// <summary>
+    /// Wartet die konfigurierte Anzeigedauer ab und lädt anschließend den nächsten Level.
+    /// Verwendet echte Zeit, damit auch bei pausiertem Spiel fortgefahren wird.
+    /// </summary>
+    private System.Collections.IEnumerator LoadNextLevelRoutine()
+    {
+        float delay = Mathf.Max(0.1f, levelCompleteDisplayTime);
+        yield return new WaitForSecondsRealtime(delay);
+        LoadNextLevel();
     }
 
     private void LoadNextLevel()
@@ -629,7 +639,7 @@ public class LevelManager : MonoBehaviour
     private string DetermineNextScene(string currentScene)
     {
         // After Level3 always switch to procedurally generated levels
-        if (currentScene.StartsWith("Level3"))
+        if (currentScene == "Level3" || currentScene == "Level_3")
             return "GeneratedLevel";
 
         // Use progression profile if available


### PR DESCRIPTION
## Summary
- trigger next level loading with a realtime coroutine after last collectible
- route post-Level3 progression to generated levels

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_689243faeb548324a9a6b2c76c0ead16