### PR TITLE
Fix collectible counter showing extra item

### DIFF
--- a/Assets/Scripts/UIController.cs
+++ b/Assets/Scripts/UIController.cs
@@ -131,9 +131,8 @@ public class UIController : MonoBehaviour
             LevelManager.Instance.OnLevelCompleted += OnLevelCompleted;
             LevelManager.Instance.OnCollectibleCountChanged += OnCollectibleCountChanged;
 
-            // Startwerte setzen
-            var cfg = LevelManager.Instance.GetLevelConfiguration();
-            OnCollectibleCountChanged(cfg.collectiblesRemaining, cfg.totalCollectibles);
+            // ensure the counter reflects the actual objects present in the scene
+            LevelManager.Instance.RescanCollectibles();
         }
     }
 


### PR DESCRIPTION
## Summary
- ensure UI controller rescans LevelManager collectibles so the counter matches the level's actual objects

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_689287abd1a08324a9401c5dd5a0b224