### PR TITLE
Exclude inactive collectibles from level counts

### DIFF
--- a/Assets/Scripts/LevelManager.cs
+++ b/Assets/Scripts/LevelManager.cs
@@ -2,6 +2,7 @@ using UnityEngine;
 using UnityEngine.SceneManagement;
 using System.Collections.Generic;
 using System.Linq;
+using RollABall.Utility;
 
 [System.Serializable]
 public class LevelConfiguration
@@ -140,7 +141,7 @@ public class LevelManager : MonoBehaviour
         // Eindeutige Liste erzwingen - alle null-Referenzen und doppelt referenzierte
         // GameObjects entfernen
         levelCollectibles = levelCollectibles
-            .Where(c => c != null && !c.IsCollected)
+            .Where(c => c != null && c.gameObject.activeInHierarchy && !c.IsCollected)
             .GroupBy(c => c.gameObject)
             .Select(g => g.First())
             .ToList();
@@ -149,7 +150,13 @@ public class LevelManager : MonoBehaviour
         levelConfig.collectiblesRemaining = levelConfig.totalCollectibles;
 
         if (debugMode)
+        {
+            foreach (var collectible in levelCollectibles)
+            {
+                Debug.Log($"[LevelManager] Collectible gezählt: {collectible.name} | Pfad: {collectible.transform.GetHierarchyPath()} | Aktiv: {collectible.gameObject.activeInHierarchy}");
+            }
             Debug.Log($"[LevelManager] InitializeCollectibleCounts: {levelConfig.totalCollectibles} eindeutige Collectibles");
+        }
     }
 
     private void FindGoalZone()

--- a/Assets/Scripts/Utility/TransformExtensions.cs
+++ b/Assets/Scripts/Utility/TransformExtensions.cs
@@ -1,0 +1,26 @@
+using UnityEngine;
+
+namespace RollABall.Utility
+{
+    /// <summary>
+    /// Extension methods for <see cref="Transform"/> instances.
+    /// </summary>
+    public static class TransformExtensions
+    {
+        /// <summary>
+        /// Builds the full hierarchy path of the transform within the scene.
+        /// </summary>
+        /// <param name="transform">Transform to evaluate.</param>
+        /// <returns>Slash separated path from the scene root to the object.</returns>
+        public static string GetHierarchyPath(this Transform transform)
+        {
+            string path = transform.name;
+            while (transform.parent != null)
+            {
+                transform = transform.parent;
+                path = transform.name + "/" + path;
+            }
+            return path;
+        }
+    }
+}

--- a/Assets/Scripts/Utility/TransformExtensions.cs.meta
+++ b/Assets/Scripts/Utility/TransformExtensions.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 56f71a731798437f906109f0ebb90809


### PR DESCRIPTION
## Summary
- ignore inactive collectibles when tallying level goals
- log each counted collectible with its hierarchy path in debug mode
- add `TransformExtensions.GetHierarchyPath` for debug output

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*

------
https://chatgpt.com/codex/tasks/task_e_68928a436a6c8324a793771dcbfd1c0c