### PR TITLE
Fix collectible counter not updating in later levels

### DIFF
--- a/Assets/Scripts/LevelManager.cs
+++ b/Assets/Scripts/LevelManager.cs
@@ -43,9 +43,6 @@ public class LevelManager : MonoBehaviour
     [SerializeField] private bool autoFindCollectibles = true;
     public bool AutoFindCollectibles => autoFindCollectibles;
 
-    [Header("UI References")]
-    [SerializeField] private UIController uiController;
-
     [Header("Level Progression")]
     [SerializeField] private LevelProgressionProfile progressionProfile;
 
@@ -102,9 +99,6 @@ public class LevelManager : MonoBehaviour
         levelCollectibles.Clear();
         collectedCollectibles.Clear();
         registeredCollectibles.Clear();
-
-        if (!uiController)
-            uiController = FindFirstObjectByType<UIController>();
 
         levelStartTime = Time.time;
     }
@@ -341,7 +335,6 @@ public class LevelManager : MonoBehaviour
 
     private void UpdateUI()
     {
-        if (!uiController) return;
         OnCollectibleCountChanged?.Invoke(levelConfig.collectiblesRemaining, levelConfig.totalCollectibles);
     }
 


### PR DESCRIPTION
## Summary
- remove UIController dependency from LevelManager
- always fire collectible count updates

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68928fd3fdb48324b68ef3fb9bd4f491